### PR TITLE
Visualize bone rotation around the axis of the bones

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -58,7 +58,12 @@ async fn overlay(
 
     let loop_ = async {
         let mut hidden_bones: HashSet<BoneKind> = HashSet::new();
+        let mut rotation = 0.0f32;
         loop {
+            rotation += 0.01;
+            for (_, bone) in skeleton.bones.iter_mut() {
+                bone.set_rotation(rotation);
+            }
             recv.changed()
                 .await
                 .wrap_err("Error while attempting to watch for feed update")?;


### PR DESCRIPTION
This is eventually intended to be generated from the bone rotation,
to obtain information we discard when rendering as a cylinder.

For now, it's constantly rotating, for demonstration purposes.
There's some interesting artifacting going on here, I'd like to stick
the skeleton in a single spot so that I can try to more closely observe
what's going on.

setup as a draft pr for visibility (it's not complete, I've only done the first step towards visualizing it, math is yet to come), relies on https://github.com/TheButlah/ovr_overlay/pull/5