### PR TITLE
firmware: Get nrf to compile at same time as esp32c3

### DIFF
--- a/firmware/.cargo/config.toml
+++ b/firmware/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.riscv32imc-unknown-none-elf]
 rustflags = [
+  # For esp-hal
   "-C",
   "link-arg=-Tlinkall.x",
   # For esp-backtrace
@@ -9,6 +10,23 @@ rustflags = [
   "-C",
   "link-arg=-Tdefmt.x",
 ]
+
+[target.thumbv7em-none-eabihf]
+rustflags = [
+  # TODO: Where is this from?
+  "-C",
+  "link-arg=--nmagic",
+  # For cortex-m-rt
+  "-C",
+  "link-arg=-Tlink.x",
+  # For defmt 
+  "-C",
+  "link-arg=-Tdefmt.x",
+  # For safety against stack overflows. Optional.
+  "-C",
+  "linker=flip-link", # Requires you to `cargo install flip-link`
+]
+
 
 [build]
 # We compile without atomics, because its faster than using atomic trap handler

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-cortex-m"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b309e7a89884824cb3c8e5f882024269c95e90b2f746344f2914423ac33c452"
+dependencies = [
+ "cortex-m",
+ "linked_list_allocator",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +55,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version 0.2.3",
+]
+
+[[package]]
 name = "bare-metal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,10 +82,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bytemuck"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
 
 [[package]]
 name = "byteorder"
@@ -69,16 +106,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cortex-m"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70858629a458fdfd39f9675c4dc309411f2a3f83bede76988d81bf1a0ecee9e0"
+dependencies = [
+ "bare-metal 0.2.5",
+ "bitfield",
+ "critical-section",
+ "embedded-hal",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-rt"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d3328b8b5534f0c90acd66b68950f2763b37e0173cac4d8b4937c4a80761f9"
+dependencies = [
+ "cortex-m-rt-macros",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f6f3e36f203cfedbc78b357fb28730aa2c6dc1ab060ee5c2405e843988d3c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "darling"
@@ -253,6 +335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33dfba9e6c113f2fd8537c943780a7345945e66c86972e356b1152e19481bcf5"
 
 [[package]]
+name = "embedded-storage"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "156d7a2fdd98ebbf9ae579cbceca3058cff946e13f8e17b90e3511db0508c723"
+
+[[package]]
 name = "embedded-svc"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,7 +381,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747141836aa66f690bb8434f7044781b629c686fa699581aa3940f1b8ffee4ea"
 dependencies = [
- "bare-metal",
+ "bare-metal 1.0.0",
  "linked_list_allocator",
  "riscv 0.8.0",
  "xtensa-lx",
@@ -410,6 +498,9 @@ checksum = "535edfc411b7b1c07e47f94b20706fbf1344ffe8bdc722fce17ba25cddeef052"
 name = "firmware"
 version = "0.0.0"
 dependencies = [
+ "alloc-cortex-m",
+ "cortex-m",
+ "cortex-m-rt",
  "defmt",
  "defmt-rtt",
  "defmt_esp_println",
@@ -426,11 +517,24 @@ dependencies = [
  "mpu6050-dmp",
  "nalgebra",
  "nb 1.0.0",
+ "nrf52840-hal",
  "panic_defmt",
  "riscv 0.10.0",
  "riscv-rt 0.10.0",
  "smoltcp",
  "static_cell",
+]
+
+[[package]]
+name = "fixed"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418922d2c280b8c68f82699494cc8c48f392233233a9a8b9a48a57a36c0ad0ef"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "typenum",
 ]
 
 [[package]]
@@ -479,6 +583,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b1b088ad0a967aa29540456b82fc8903f854775d33f71e9709c4efb3dfbfd2"
 
 [[package]]
+name = "half"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,7 +608,7 @@ checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill 0.1.11",
  "hash32",
- "rustc_version",
+ "rustc_version 0.4.0",
  "spin",
  "stable_deref_trait",
 ]
@@ -621,6 +734,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bcece43b12349917e096cddfa66107277f123e6c96a5aea78711dc601a47152"
 
 [[package]]
+name = "nrf-hal-common"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd244c63d588066d75cffdcae8a03299fd5fb272e36bdde4a9f922f3e4bc6e4b"
+dependencies = [
+ "cast",
+ "cfg-if",
+ "cortex-m",
+ "embedded-dma",
+ "embedded-hal",
+ "embedded-storage",
+ "fixed",
+ "nb 1.0.0",
+ "nrf-usbd",
+ "nrf52840-pac",
+ "rand_core",
+ "void",
+]
+
+[[package]]
+name = "nrf-usbd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b2907c0b3ec4d264981c1fc5a2321d51c463d5a63d386e573f00e84d5495e6"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "usb-device",
+ "vcell",
+]
+
+[[package]]
+name = "nrf52840-hal"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54757ec98f38331889d1d6c535edb5dd543c762751abfe507f2d644b30f6d4f"
+dependencies = [
+ "embedded-hal",
+ "nrf-hal-common",
+ "nrf52840-pac",
+]
+
+[[package]]
+name = "nrf52840-pac"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30713f36f1be02e5bc9abefa30eae4a1f943d810f199d4923d3ad062d1be1b3d"
+dependencies = [
+ "cortex-m",
+ "vcell",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,7 +929,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2856a701069e2d262b264750d382407d272d5527f7a51d3777d1805b4e2d3c"
 dependencies = [
- "bare-metal",
+ "bare-metal 1.0.0",
  "bit_field",
  "embedded-hal",
 ]
@@ -768,7 +940,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fc4bc7113424814738fe79755a5764e392b3d4d1bc757e6aa6f61cede32095"
 dependencies = [
- "bare-metal",
+ "bare-metal 1.0.0",
  "bit_field",
  "embedded-hal",
 ]
@@ -842,11 +1014,20 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.14",
 ]
 
 [[package]]
@@ -857,9 +1038,24 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -968,6 +1164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
+name = "usb-device"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,12 +1188,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "volatile-register"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+dependencies = [
+ "vcell",
+]
+
+[[package]]
 name = "xtensa-lx"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b874b2b60f9c25682e0961fd53a802053e6950f7567bc6f2d6c734fb6d93f45a"
 dependencies = [
- "bare-metal",
+ "bare-metal 1.0.0",
  "mutex-trait",
  "r0",
  "spin",

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -41,13 +41,20 @@ default = ["mcu-esp32c3", "imu-mpu6050", "log-rtt", "net-wifi"]
 # TODO: actually support another microcontroller
 # Supported microcontrollers
 mcu-esp32c3 = [
+  "dep:esp32c3-hal",
   "defmt_esp_println?/esp32c3",
   "esp-backtrace/esp32c3",
   "dep:riscv",
   "dep:riscv-rt",
   "dep:esp-alloc",
+  "dep:embedded-svc",
 ]
-mcu-nrf52840 = []
+mcu-nrf52840 = [
+  "dep:cortex-m",
+  "dep:cortex-m-rt",
+  "dep:nrf52840-hal",
+  "dep:alloc-cortex-m",
+]
 
 # Wi-fi dependencies
 net-wifi = ["dep:esp-wifi", "dep:smoltcp"] # use wifi
@@ -62,20 +69,31 @@ log-usb-serial = ["defmt_esp_println/jtag_serial"]
 log-uart = ["defmt_esp_println/uart"]
 
 # Enable to flash without needing `espflash`
-direct-boot = ["esp32c3-hal/direct-boot"]
+direct-boot = ["esp32c3-hal?/direct-boot"]
 
 
 [dependencies]
-esp32c3-hal = { version = "0.3", features = [
+
+# mcu-esp32c3 stuff
+esp32c3-hal = { version = "0.3", optional = true, features = [
   #"embassy",
   #"embassy-time-systick",
   #"direct-boot",
 ] }
 riscv-rt = { verison = "0.10", optional = true }
 riscv = { version = "0.10", optional = true }
-esp-alloc = { version = "0.1", features = ["oom-handler"], optional = true }
+esp-alloc = { version = "0.1", optional = true }
+
+# mcu-nrf52840 stuff
+nrf52840-hal = { version = "0.16", optional = true, default-features = false }
+alloc-cortex-m = { version = "0.4", optional = true }
+cortex-m = { version = "0.7", optional = true, features = [
+  "critical-section-single-core",
+] }
+cortex-m-rt = { version = "0.7", optional = true }
+
 embedded-hal = "0.2"
-embedded-svc = { version = "0.23", default-features = false, features = [
+embedded-svc = { version = "0.23", default-features = false, optional = true, features = [
   #  "nightly",
 ] }
 

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -40,7 +40,14 @@ default = ["mcu-esp32c3", "imu-mpu6050", "log-rtt", "net-wifi"]
 
 # TODO: actually support another microcontroller
 # Supported microcontrollers
-mcu-esp32c3 = ["defmt_esp_println?/esp32c3", "esp-backtrace/esp32c3"]
+mcu-esp32c3 = [
+  "defmt_esp_println?/esp32c3",
+  "esp-backtrace/esp32c3",
+  "dep:riscv",
+  "dep:riscv-rt",
+  "dep:esp-alloc",
+]
+mcu-nrf52840 = []
 
 # Wi-fi dependencies
 net-wifi = ["dep:esp-wifi", "dep:smoltcp"] # use wifi
@@ -64,9 +71,9 @@ esp32c3-hal = { version = "0.3", features = [
   #"embassy-time-systick",
   #"direct-boot",
 ] }
-riscv-rt = "0.10"
-riscv = "0.10"
-esp-alloc = { version = "0.1", features = ["oom-handler"] }
+riscv-rt = { verison = "0.10", optional = true }
+riscv = { version = "0.10", optional = true }
+esp-alloc = { version = "0.1", features = ["oom-handler"], optional = true }
 embedded-hal = "0.2"
 embedded-svc = { version = "0.23", default-features = false, features = [
   #  "nightly",

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -16,6 +16,7 @@ The ESP32-C3 also claims to have a stronger wifi signal, which will help with la
 ### First time setup
 1. Install cargo and rust via the instructions at https://rustup.rs
 1. run `cargo install cargo-embed`
+1. run `cargo install flip-link`
 
 ### Flashing
 Simply run `cargo embed flash` from this folder to flash the firmware.

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -1,6 +1,6 @@
 use feature_utils::mandatory_and_unique;
 
-mandatory_and_unique!("mcu-esp32c3");
+mandatory_and_unique!("mcu-esp32c3", "mcu-nrf52840");
 mandatory_and_unique!("imu-mpu6050");
 mandatory_and_unique!("log-rtt", "log-usb-serial");
 mandatory_and_unique!("net-wifi", "net-stubbed");

--- a/firmware/src/aliases.rs
+++ b/firmware/src/aliases.rs
@@ -6,6 +6,13 @@ pub mod ඞ {
 	pub type I2cConcrete = esp32c3_hal::i2c::I2C<esp32c3_hal::pac::I2C0>;
 }
 
+#[cfg(feature = "mcu-nrf52840")]
+pub mod ඞ {
+	pub use nrf52840_hal::Delay as DelayConcrete;
+
+	pub type I2cConcrete = nrf52840_hal::Twim<nrf52840_hal::pac::TWIM0>;
+}
+
 pub trait I2c:
 	embedded_hal::blocking::i2c::Write<Error = <Self as I2c>::Error>
 	+ embedded_hal::blocking::i2c::WriteRead<Error = <Self as I2c>::Error>

--- a/firmware/src/globals.rs
+++ b/firmware/src/globals.rs
@@ -1,13 +1,27 @@
 extern crate alloc;
 
 // Set up global heap allocator
+#[cfg(feature = "mcu-esp32c3")]
 #[global_allocator]
 static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
+
+#[cfg(feature = "mcu-nrf52840")]
+#[global_allocator]
+static ALLOCATOR: alloc_cortex_m::CortexMHeap = alloc_cortex_m::CortexMHeap::empty();
+
+#[alloc_error_handler]
+fn oom(_: core::alloc::Layout) -> ! {
+	panic!("Allocation failed, out of memory");
+}
+// #[cfg(feature = "mcu-nrf52840")]
+// #[alloc_error_handler]
+// fn oom(_: core::alloc::Layout) -> ! {
+// 	loop {}
+// }
 
 // Set up backtraces
 // use esp_backtrace as _;
 
-use defmt::error;
 use panic_defmt as _;
 
 // Set up global defmt logger
@@ -19,22 +33,28 @@ use defmt_esp_println as _;
 #[cfg(feature = "log-rtt")]
 use defmt_rtt as _;
 
-// Choose the embedded hal based on the hardware (for now its just esp32c3)
-pub use esp32c3_hal as ehal;
-
 /// Sets up any global state
 pub fn setup() {
 	// Initialize the global allocator BEFORE you use it
 	{
 		const HEAP_SIZE: usize = 10 * 1024;
 		static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
-		unsafe { ALLOCATOR.init(HEAP.as_mut_ptr(), HEAP_SIZE) }
+
+		unsafe {
+			#[cfg(feature = "mcu-esp32c3")]
+			ALLOCATOR.init(HEAP.as_mut_ptr(), HEAP_SIZE);
+			#[cfg(feature = "mcu-nrf52840")]
+			ALLOCATOR.init(HEAP.as_mut_ptr() as usize, HEAP_SIZE);
+		}
 	}
 }
 
 /// This will be called when a hardware exception occurs
+#[cfg(feature = "mcu-esp32c3")]
 #[export_name = "ExceptionHandler"]
 pub fn custom_exception_handler(trap_frame: &riscv_rt::TrapFrame) -> ! {
+	use defmt::error;
+
 	let mepc = riscv::register::mepc::read();
 	let mcause = riscv::register::mcause::read();
 	let mtval = riscv::register::mtval::read();

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -2,6 +2,8 @@
 #![no_main]
 // Needed for embassy macros
 #![feature(type_alias_impl_trait)]
+// Needed to use `alloc` + `no_std`
+#![feature(alloc_error_handler)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 mod aliases;
@@ -13,17 +15,22 @@ mod utils;
 
 use defmt::debug;
 use embassy_executor::{task, Executor};
-use riscv_rt::entry;
+use embedded_hal::blocking::delay::DelayMs;
 use static_cell::StaticCell;
+
+#[cfg(feature = "mcu-nrf52840")]
+use cortex_m_rt::entry;
+#[cfg(feature = "mcu-esp32c3")]
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {
 	self::globals::setup();
 	debug!("Booted");
 
-	let p = self::peripherals::ඞ::get_peripherals();
+	let mut p = self::peripherals::ඞ::get_peripherals();
 	debug!("Initialized peripherals");
-	p.delay.delay(1000);
+	p.delay.delay_ms(1000 as u32);
 
 	static EXECUTOR: StaticCell<Executor> = StaticCell::new();
 	EXECUTOR.init(Executor::new()).run(move |spawner| {

--- a/firmware/src/peripherals/esp32c3.rs
+++ b/firmware/src/peripherals/esp32c3.rs
@@ -1,4 +1,5 @@
 use super::Peripherals;
+use crate::aliases::ඞ::DelayConcrete;
 use crate::aliases::ඞ::I2cConcrete;
 
 use fugit::RateExtU32;
@@ -10,7 +11,7 @@ use esp32c3_hal::{
 	Rtc,
 };
 
-pub fn get_peripherals() -> Peripherals<I2cConcrete, esp32c3_hal::Delay> {
+pub fn get_peripherals() -> Peripherals<I2cConcrete, DelayConcrete> {
 	let p = esp32c3_hal::pac::Peripherals::take().unwrap();
 
 	let mut system = p.SYSTEM.split();

--- a/firmware/src/peripherals/mod.rs
+++ b/firmware/src/peripherals/mod.rs
@@ -4,6 +4,10 @@
 #[path = "esp32c3.rs"]
 pub mod ඞ;
 
+#[cfg(feature = "mcu-nrf52840")]
+#[path = "nrf52840.rs"]
+pub mod ඞ;
+
 use crate::aliases::I2c;
 
 pub struct Peripherals<I: I2c, D: embedded_hal::blocking::delay::DelayMs<u32>> {

--- a/firmware/src/peripherals/nrf52840.rs
+++ b/firmware/src/peripherals/nrf52840.rs
@@ -1,0 +1,7 @@
+use super::Peripherals;
+use crate::aliases::ඞ::DelayConcrete;
+use crate::aliases::ඞ::I2cConcrete;
+
+pub fn get_peripherals() -> Peripherals<I2cConcrete, DelayConcrete> {
+	todo!()
+}


### PR DESCRIPTION
This provides initial setup for the nrf52840. It can be enabled by choosing `cargo build --no-default-features --feature mcu-nrf52840,log-rtt,imu-mpu6050,net-stubbed` instead of the default features.

For now, the goal is to get things to compile for nrf, even if they may crash at runtime. They will crash because so far I have used a `todo!()` on the actual peripherals.

Closes #86 