### PR TITLE
firmware: Switched from nrf52840-hal to embassy-nrf

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -106,12 +106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,7 +120,7 @@ dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
  "critical-section",
- "embedded-hal",
+ "embedded-hal 0.2.7",
  "volatile-register",
 ]
 
@@ -280,6 +274,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-cortex-m"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2#2528f451387e6c7b27c3140cd87d47521d1971a2"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+ "cfg-if",
+ "cortex-m",
+ "critical-section",
+ "embassy-executor",
+ "embassy-hal-common",
+ "embassy-macros",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2)",
+]
+
+[[package]]
+name = "embassy-embedded-hal"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2#2528f451387e6c7b27c3140cd87d47521d1971a2"
+dependencies = [
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2)",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0-alpha.9",
+ "embedded-storage",
+ "nb 1.0.0",
+]
+
+[[package]]
 name = "embassy-executor"
 version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2#2528f451387e6c7b27c3140cd87d47521d1971a2"
@@ -288,6 +309,7 @@ dependencies = [
  "cfg-if",
  "critical-section",
  "embassy-macros",
+ "embassy-time 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2)",
  "futures-util",
  "static_cell",
 ]
@@ -299,6 +321,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e5367165d347c039360f784812f493b001583ab6a3dd8622f4ce9c30374ec3"
 
 [[package]]
+name = "embassy-hal-common"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2#2528f451387e6c7b27c3140cd87d47521d1971a2"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "embassy-macros"
 version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2#2528f451387e6c7b27c3140cd87d47521d1971a2"
@@ -307,6 +337,84 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "embassy-nrf"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2#2528f451387e6c7b27c3140cd87d47521d1971a2"
+dependencies = [
+ "cfg-if",
+ "cortex-m",
+ "cortex-m-rt",
+ "critical-section",
+ "embassy-cortex-m",
+ "embassy-embedded-hal",
+ "embassy-hal-common",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2)",
+ "embassy-time 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2)",
+ "embedded-hal 0.2.7",
+ "embedded-storage",
+ "fixed",
+ "futures",
+ "nrf52840-pac",
+ "rand_core",
+]
+
+[[package]]
+name = "embassy-sync"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ea38e6ea5d0361d087680f786c19a1454becb06174790280534a3be05ed839"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+ "cfg-if",
+ "critical-section",
+ "embedded-io",
+ "futures-util",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-sync"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2#2528f451387e6c7b27c3140cd87d47521d1971a2"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+ "cfg-if",
+ "critical-section",
+ "embedded-io",
+ "futures-util",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81c0c57d163dba8ff55a874966d9a1ae755859028308833923a1edeec1a6c215"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+ "cfg-if",
+ "critical-section",
+ "embassy-sync 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embedded-hal 0.2.7",
+ "futures-util",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2#2528f451387e6c7b27c3140cd87d47521d1971a2"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+ "cfg-if",
+ "critical-section",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=2528f451387e6c7b27c3140cd87d47521d1971a2)",
+ "embedded-hal 0.2.7",
+ "futures-util",
+ "heapless",
 ]
 
 [[package]]
@@ -327,6 +435,12 @@ dependencies = [
  "nb 0.1.3",
  "void",
 ]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129b101ddfee640565f7c07b301a31d95aa21e5acef21a491c307139f5fa4c91"
 
 [[package]]
 name = "embedded-io"
@@ -405,7 +519,7 @@ dependencies = [
  "cfg-if",
  "critical-section",
  "embedded-dma",
- "embedded-hal",
+ "embedded-hal 0.2.7",
  "esp-hal-procmacros",
  "esp32c3",
  "fugit",
@@ -445,7 +559,7 @@ source = "git+https://github.com/esp-rs/esp-wifi.git?rev=9034a26#9034a260bce603b
 dependencies = [
  "atomic-polyfill 1.0.1",
  "critical-section",
- "embedded-hal",
+ "embedded-hal 0.2.7",
  "embedded-io",
  "embedded-svc",
  "enumset",
@@ -481,7 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98fbc9b407fa1d70e9241d6d0baf016dc76383cf1d9cc9c6b3880d9c75291298"
 dependencies = [
  "cfg-if",
- "embedded-hal",
+ "embedded-hal 0.2.7",
  "esp-hal-common",
  "r0",
  "riscv 0.10.0",
@@ -506,7 +620,9 @@ dependencies = [
  "defmt_esp_println",
  "embassy-executor",
  "embassy-futures",
- "embedded-hal",
+ "embassy-nrf",
+ "embassy-time 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embedded-hal 0.2.7",
  "embedded-svc",
  "esp-alloc",
  "esp-backtrace",
@@ -517,7 +633,6 @@ dependencies = [
  "mpu6050-dmp",
  "nalgebra",
  "nb 1.0.0",
- "nrf52840-hal",
  "panic_defmt",
  "riscv 0.10.0",
  "riscv-rt 0.10.0",
@@ -553,10 +668,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
@@ -571,6 +722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -676,7 +828,7 @@ name = "mpu6050-dmp"
 version = "0.2.0"
 source = "git+https://github.com/TheButlah/mpu6050-dmp-rs?rev=77128a75a51547baadc0f0ef99aba4432e848f10#77128a75a51547baadc0f0ef99aba4432e848f10"
 dependencies = [
- "embedded-hal",
+ "embedded-hal 0.2.7",
  "libm",
 ]
 
@@ -734,55 +886,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bcece43b12349917e096cddfa66107277f123e6c96a5aea78711dc601a47152"
 
 [[package]]
-name = "nrf-hal-common"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd244c63d588066d75cffdcae8a03299fd5fb272e36bdde4a9f922f3e4bc6e4b"
-dependencies = [
- "cast",
- "cfg-if",
- "cortex-m",
- "embedded-dma",
- "embedded-hal",
- "embedded-storage",
- "fixed",
- "nb 1.0.0",
- "nrf-usbd",
- "nrf52840-pac",
- "rand_core",
- "void",
-]
-
-[[package]]
-name = "nrf-usbd"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b2907c0b3ec4d264981c1fc5a2321d51c463d5a63d386e573f00e84d5495e6"
-dependencies = [
- "cortex-m",
- "critical-section",
- "usb-device",
- "vcell",
-]
-
-[[package]]
-name = "nrf52840-hal"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54757ec98f38331889d1d6c535edb5dd543c762751abfe507f2d644b30f6d4f"
-dependencies = [
- "embedded-hal",
- "nrf-hal-common",
- "nrf52840-pac",
-]
-
-[[package]]
 name = "nrf52840-pac"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30713f36f1be02e5bc9abefa30eae4a1f943d810f199d4923d3ad062d1be1b3d"
 dependencies = [
  "cortex-m",
+ "cortex-m-rt",
  "vcell",
 ]
 
@@ -931,7 +1041,7 @@ checksum = "5e2856a701069e2d262b264750d382407d272d5527f7a51d3777d1805b4e2d3c"
 dependencies = [
  "bare-metal 1.0.0",
  "bit_field",
- "embedded-hal",
+ "embedded-hal 0.2.7",
 ]
 
 [[package]]
@@ -942,7 +1052,7 @@ checksum = "73fc4bc7113424814738fe79755a5764e392b3d4d1bc757e6aa6f61cede32095"
 dependencies = [
  "bare-metal 1.0.0",
  "bit_field",
- "embedded-hal",
+ "embedded-hal 0.2.7",
 ]
 
 [[package]]
@@ -953,7 +1063,7 @@ checksum = "169fa82a2be03db484b13863f6a88f7f154a027a332c471cc164775671e81a5a"
 dependencies = [
  "bit_field",
  "critical-section",
- "embedded-hal",
+ "embedded-hal 0.2.7",
 ]
 
 [[package]]
@@ -1162,12 +1272,6 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
-
-[[package]]
-name = "usb-device"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 
 [[package]]
 name = "vcell"

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -52,8 +52,11 @@ mcu-esp32c3 = [
 mcu-nrf52840 = [
   "dep:cortex-m",
   "dep:cortex-m-rt",
-  "dep:nrf52840-hal",
   "dep:alloc-cortex-m",
+  "dep:embassy-time",
+  "embassy-nrf/nrf52840",
+  "embassy-nrf/time-driver-rtc1",
+  "embassy-executor/integrated-timers",
 ]
 
 # Wi-fi dependencies
@@ -85,7 +88,7 @@ riscv = { version = "0.10", optional = true }
 esp-alloc = { version = "0.1", optional = true }
 
 # mcu-nrf52840 stuff
-nrf52840-hal = { version = "0.16", optional = true, default-features = false }
+embassy-nrf = { optional = true, default-features = false, git = "https://github.com/embassy-rs/embassy", rev = "2528f451387e6c7b27c3140cd87d47521d1971a2" }
 alloc-cortex-m = { version = "0.4", optional = true }
 cortex-m = { version = "0.7", optional = true, features = [
   "critical-section-single-core",
@@ -103,10 +106,10 @@ embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "2528f
   #"integrated-timers",
   "nightly",
 ] }
-#embassy-time = { version = "0.1.0", features = [
-#  "tick-hz-16_000_000",
-#  "unstable-traits",
-#] }
+embassy-time = { version = "0.1.0", optional = true, features = [
+  # "tick-hz-16_000_000",
+  # "unstable-traits",
+] }
 
 # Wi-Fi
 esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", rev = "9034a26", features = [
@@ -156,9 +159,11 @@ feature_utils = "0.0.0"
 # Enable non-default I2C addresses and InitError
 mpu6050-dmp = { git = "https://github.com/TheButlah/mpu6050-dmp-rs", rev = "77128a75a51547baadc0f0ef99aba4432e848f10" }
 
+# Emable use of `atomic-polyfill`
 defmt = { git = "https://github.com/TheButlah/defmt", rev = "b5d5e316ea56250dcb25b3549bcf4bfdb1687796" }
 defmt-rtt = { git = "https://github.com/TheButlah/defmt", rev = "b5d5e316ea56250dcb25b3549bcf4bfdb1687796" }
 
+# Necessary for esp-wifi to not be bugged
 # https://github.com/esp-rs/esp-wifi/blob/9b644387a54a5ace93d4280f29075ad2a9e9a8ed/README.md
 # https://github.com/esp-rs/esp-wifi/issues/88#issuecomment-1332363697
 [profile.dev.package.esp-wifi]

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -8,4 +8,17 @@ mandatory_and_unique!("net-wifi", "net-stubbed");
 fn main() {
 	#[cfg(feature = "net-wifi")]
 	println!("cargo:rustc-link-arg=-Tesp32c3_rom_functions.x"); // esp-wifi
+
+	#[cfg(feature = "mcu-nrf52840")]
+	{
+		use std::{env, fs, path};
+		let out = path::PathBuf::from(env::var("OUT_DIR").unwrap());
+		fs::write(
+			out.join("memory.x"),
+			include_bytes!("linker_scripts/memory.x.nrf52840"),
+		)
+		.unwrap();
+		// println!("cargo:rustc-link-arg=-Tmemory.x.nrf52840");
+		println!("cargo:rustc-link-search={}", out.display());
+	}
 }

--- a/firmware/linker_scripts/memory.x.nrf52840
+++ b/firmware/linker_scripts/memory.x.nrf52840
@@ -1,0 +1,23 @@
+/* Linker script for the nRF52 - WITH SOFT DEVICE */
+MEMORY
+{
+  /* NOTE K = KiBi = 1024 bytes */
+  FLASH : ORIGIN = 0x00026000, LENGTH = 1024K /* Change to 0x1000 if you don't have softdevice */
+  RAM : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+/* This is where the call stack will be allocated. */
+/* The stack is of the full descending type. */
+/* You may want to use this variable to locate the call stack and static
+   variables in different memory regions. Below is shown the default value */
+/* _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
+
+/* You can use this symbol to customize the location of the .text section */
+/* If omitted the .text section will be placed right after the .vector_table
+   section */
+/* This is required only on microcontrollers that store some configuration right
+   after the vector table */
+/* _stext = ORIGIN(FLASH) + 0x400; */
+
+/* Size of the heap (in bytes) */
+/* _heap_size = 1024; */

--- a/firmware/rust-toolchain.toml
+++ b/firmware/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly"
-targets = ["riscv32imc-unknown-none-elf"]
+targets = ["riscv32imc-unknown-none-elf", "thumbv7em-none-eabihf"]
 profile = "default"
 components = ["llvm-tools-preview", "rust-src", "rustfmt"]

--- a/firmware/src/aliases.rs
+++ b/firmware/src/aliases.rs
@@ -3,14 +3,15 @@ pub mod ඞ {
 	pub use esp32c3_hal::ehal;
 	pub use esp32c3_hal::Delay as DelayConcrete;
 
-	pub type I2cConcrete = esp32c3_hal::i2c::I2C<esp32c3_hal::pac::I2C0>;
+	pub type I2cConcrete<'a> = esp32c3_hal::i2c::I2C<esp32c3_hal::pac::I2C0>;
 }
 
 #[cfg(feature = "mcu-nrf52840")]
 pub mod ඞ {
-	pub use nrf52840_hal::Delay as DelayConcrete;
+	pub use embassy_time::Delay as DelayConcrete;
 
-	pub type I2cConcrete = nrf52840_hal::Twim<nrf52840_hal::pac::TWIM0>;
+	pub type I2cConcrete<'a> =
+		embassy_nrf::twim::Twim<'a, embassy_nrf::peripherals::TWISPI0>;
 }
 
 pub trait I2c:

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -46,7 +46,7 @@ async fn network_task() {
 
 #[task]
 async fn imu_task(
-	i2c: crate::aliases::ඞ::I2cConcrete,
+	i2c: crate::aliases::ඞ::I2cConcrete<'static>,
 	delay: crate::aliases::ඞ::DelayConcrete,
 ) {
 	crate::imu::imu_task(i2c, delay).await

--- a/firmware/src/peripherals/esp32c3.rs
+++ b/firmware/src/peripherals/esp32c3.rs
@@ -11,7 +11,7 @@ use esp32c3_hal::{
 	Rtc,
 };
 
-pub fn get_peripherals() -> Peripherals<I2cConcrete, DelayConcrete> {
+pub fn get_peripherals() -> Peripherals<I2cConcrete<'static>, DelayConcrete> {
 	let p = esp32c3_hal::pac::Peripherals::take().unwrap();
 
 	let mut system = p.SYSTEM.split();

--- a/firmware/src/peripherals/nrf52840.rs
+++ b/firmware/src/peripherals/nrf52840.rs
@@ -2,6 +2,20 @@ use super::Peripherals;
 use crate::aliases::ඞ::DelayConcrete;
 use crate::aliases::ඞ::I2cConcrete;
 
-pub fn get_peripherals() -> Peripherals<I2cConcrete, DelayConcrete> {
-	todo!()
+use defmt::debug;
+use embassy_nrf::interrupt;
+use embassy_nrf::twim::{self, Twim};
+
+pub fn get_peripherals() -> Peripherals<I2cConcrete<'static>, DelayConcrete> {
+	let p = embassy_nrf::init(Default::default());
+	debug!("Initializing TWIM (I2C controller)");
+
+	// IDK how this works, code is from here:
+	// https://github.com/embassy-rs/embassy/blob/f109e73c6d7ef2ad93102b7c8223f5cef30ef36f/examples/nrf/src/bin/twim.rs
+	let config = twim::Config::default();
+	let irq = interrupt::take!(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0);
+	let twim = Twim::new(p.TWISPI0, irq, p.P0_03, p.P0_04, config);
+
+	let delay = embassy_time::Delay;
+	Peripherals { i2c: twim, delay }
 }


### PR DESCRIPTION
In order to use embassy, we needed to use `embassy-nrf` instead of `nrf52840-hal`. This implements this such that it compiles. We are still missing a few things at runtime.