### PR TITLE
Add nrf52 usb serial logger + time drivers

### DIFF
--- a/firmware/.cargo/config.toml
+++ b/firmware/.cargo/config.toml
@@ -48,7 +48,7 @@ build-std = ["core", "alloc"]
 
 [env]
 # You can override this via environment variable when building or by changing it here
-DEFMT_LOG = "trace"
+DEFMT_LOG = "debug"
 
 # Change to your wifi's or override with environment variables.
 SSID = "ssid"

--- a/firmware/.cargo/config.toml
+++ b/firmware/.cargo/config.toml
@@ -39,9 +39,9 @@ rustflags = [
 
 [build]
 # We compile without atomics, because its faster than using atomic trap handler
-# target = "riscv32imc-unknown-none-elf"
+target = "riscv32imc-unknown-none-elf"
+# target = "thumbv7em-none-eabihf"
 # target = "xtensa-esp32-none-elf"
-target = "thumbv7em-none-eabihf"
 
 [unstable]
 build-std = ["core", "alloc"]

--- a/firmware/.cargo/config.toml
+++ b/firmware/.cargo/config.toml
@@ -39,9 +39,9 @@ rustflags = [
 
 [build]
 # We compile without atomics, because its faster than using atomic trap handler
-target = "riscv32imc-unknown-none-elf"
+# target = "riscv32imc-unknown-none-elf"
 # target = "xtensa-esp32-none-elf"
-# target = "thumbv7em-none-eabihf"
+target = "thumbv7em-none-eabihf"
 
 [unstable]
 build-std = ["core", "alloc"]

--- a/firmware/.cargo/config.toml
+++ b/firmware/.cargo/config.toml
@@ -37,7 +37,6 @@ rustflags = [
   "link-arg=-Tdefmt.x",
 ]
 
-
 [build]
 # We compile without atomics, because its faster than using atomic trap handler
 target = "riscv32imc-unknown-none-elf"

--- a/firmware/.vscode/launch.json
+++ b/firmware/.vscode/launch.json
@@ -13,15 +13,15 @@
                 "resetAfterFlashing": true,
                 "haltAfterReset": true,
             },
-            "runtimeExecutable": "/home/uri/.cargo/bin/probe-rs-debugger",
+            "runtimeExecutable": "/Users/ryan.butler/.cargo/bin/probe-rs-debugger",
             "consoleLogLevel": "Debug",
             "name": "probe_rs Executable Test",
-            "chip": "esp32c3", //!MODIFY
-            "wireProtocol": "Jtag",
+            "chip": "nrf52840", //!MODIFY
+            "wireProtocol": "Swd",
             "cwd": "${workspaceFolder}",
             "coreConfigs": [
                 {
-                    "programBinary": "${workspaceFolder}/target/riscv32imc-unknown-none-elf/debug/firmware", //!MODIFY
+                    "programBinary": "${workspaceFolder}/target/thumbv7em-none-eabihf/debug/firmware", //!MODIFY
                     "rttEnabled": true,
                 }
             ]

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
  "embassy-executor",
  "embassy-hal-common",
  "embassy-macros",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=ebc7350)",
 ]
 
 [[package]]
@@ -339,10 +339,10 @@ name = "embassy-embedded-hal"
 version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=ebc7350#ebc735008f0b1725b22c944cc5f95fe1aacc665b"
 dependencies = [
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=ebc7350)",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-alpha.9",
- "embedded-hal-async",
+ "embedded-hal-async 0.2.0-alpha.0",
  "embedded-storage",
  "embedded-storage-async",
  "nb 1.0.0",
@@ -404,12 +404,12 @@ dependencies = [
  "embassy-cortex-m",
  "embassy-embedded-hal",
  "embassy-hal-common",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=ebc7350)",
  "embassy-time",
  "embassy-usb-driver",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-alpha.9",
- "embedded-hal-async",
+ "embedded-hal-async 0.2.0-alpha.0",
  "embedded-io 0.4.0",
  "embedded-storage",
  "embedded-storage-async",
@@ -417,6 +417,20 @@ dependencies = [
  "futures",
  "nrf52840-pac",
  "rand_core",
+]
+
+[[package]]
+name = "embassy-sync"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ea38e6ea5d0361d087680f786c19a1454becb06174790280534a3be05ed839"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+ "cfg-if",
+ "critical-section",
+ "embedded-io 0.3.1",
+ "futures-util",
+ "heapless",
 ]
 
 [[package]]
@@ -440,8 +454,9 @@ dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
  "critical-section",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=ebc7350)",
  "embedded-hal 0.2.7",
+ "embedded-hal-async 0.2.0-alpha.0",
  "futures-util",
  "heapless",
 ]
@@ -452,7 +467,7 @@ version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=ebc7350#ebc735008f0b1725b22c944cc5f95fe1aacc665b"
 dependencies = [
  "embassy-futures 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=ebc7350)",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=ebc7350)",
  "embassy-usb-driver",
  "heapless",
  "ssmarshal",
@@ -491,11 +506,30 @@ checksum = "129b101ddfee640565f7c07b301a31d95aa21e5acef21a491c307139f5fa4c91"
 
 [[package]]
 name = "embedded-hal-async"
+version = "0.1.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c913f631bd08c253b85fdf0077061c64763d70e27803b04da5a49c5fb2a65057"
+dependencies = [
+ "embedded-hal 1.0.0-alpha.9",
+]
+
+[[package]]
+name = "embedded-hal-async"
 version = "0.2.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608a322808d65da06715e03109c0cb69f79a5459af756fba393ab83e875d4969"
 dependencies = [
  "embedded-hal 1.0.0-alpha.9",
+]
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0760ec0a3bf76859d5e33f39542af103f157d5b2ecfb00ace56dd461472e3a"
+dependencies = [
+ "embedded-hal 1.0.0-alpha.9",
+ "nb 1.0.0",
 ]
 
 [[package]]
@@ -608,8 +642,13 @@ checksum = "007db8d84050d19fec367bece124cccbdf6837ff0ea8e1a4fc04599148ab5ea1"
 dependencies = [
  "cfg-if",
  "critical-section",
+ "embassy-sync 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embassy-time",
  "embedded-dma",
  "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0-alpha.9",
+ "embedded-hal-async 0.1.0-alpha.3",
+ "embedded-hal-nb",
  "esp-hal-procmacros",
  "esp32",
  "esp32c3",
@@ -716,7 +755,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dccecada61692e6d3fb8349a630c1fc8cfac144cb3cb52763624db8ec1373111"
 dependencies = [
  "cfg-if",
+ "embassy-time",
  "embedded-hal 0.2.7",
+ "embedded-hal-async 0.1.0-alpha.3",
  "esp-hal-common",
  "r0",
  "riscv 0.10.0",

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/panic_defmt", "crates/defmt_esp_println"]
 [profile.dev]
 # lto doesnt work on esp32 (xtensa)
 lto = false
-opt-level = "s"
+# opt-level = "s"
 
 
 [workspace.package]
@@ -37,8 +37,8 @@ rust-version.workspace = true
 
 
 [features]
-default = ["mcu-esp32c3", "imu-stubbed", "log-rtt", "net-wifi"]
-# default = ["mcu-nrf52840", "imu-stubbed", "log-uart", "net-stubbed"]
+# default = ["mcu-esp32c3", "imu-stubbed", "log-rtt", "net-wifi"]
+default = ["mcu-nrf52840", "imu-stubbed", "log-usb-serial", "net-stubbed"]
 # default = ["mcu-esp32", "imu-stubbed", "log-uart", "net-wifi"]
 
 # Supported microcontrollers
@@ -76,7 +76,7 @@ mcu-nrf52840 = [
 
 # Wi-fi dependencies
 net-wifi = ["dep:esp-wifi", "dep:smoltcp"] # use wifi
-net-stubbed = []                           # Stubs out network   
+net-stubbed = []                           # Stubs out network
 
 # Supported IMUs
 imu-mpu6050 = ["mpu6050-dmp"]

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -14,9 +14,9 @@ rust-version.workspace = true
 
 
 [features]
-default = ["mcu-esp32c3", "imu-stubbed", "log-rtt", "net-wifi"]
-# default = ["mcu-nrf52840", "imu-stubbed", "log-uart", "net-stubbed"]
-# default = ["mcu-esp32", "imu-stubbed", "log-uart", "net-wifi"]
+default = ["mcu-esp32c3", "imu-stubbed", "log-rtt", "net-stubbed"]
+# default = ["mcu-nrf52840", "imu-stubbed", "log-usb-serial", "net-stubbed"]
+# default = ["mcu-esp32", "imu-stubbed", "log-usb-serial", "net-wifi"]
 
 # Supported microcontrollers
 mcu-esp32 = [
@@ -101,7 +101,7 @@ cortex-m-rt = { version = "0.7", optional = true }
 embassy-futures = "0.1.0"
 embassy-executor = { version = "*", features = [
   "integrated-timers",
-  "nightly",
+  "nightly",           # Needed for .spawn()
 ] }
 embassy-time = { version = "*", features = [
   # "unstable-traits",

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -1,29 +1,3 @@
-[workspace]
-resolver = "2"
-members = ["crates/panic_defmt", "crates/defmt_esp_println"]
-
-
-[profile.dev]
-# lto doesnt work on esp32 (xtensa)
-lto = false
-# opt-level = "s"
-
-
-[workspace.package]
-license = "MIT OR Apache-2.0"
-authors = ["Ryan Butler <thebutlah@gmail.com>"]
-repository = "https://github.com/SlimeVR/SlimeVR-Rust"
-
-edition = "2021"
-rust-version = "1.65"
-
-
-[workspace.dependencies]
-esp-println = { version = "0.3", default-features = false, features = [
-  "critical-section", # Necessary because otherwise I'm very sus of the soundness
-] }
-
-
 [package]
 name = "firmware"
 version = "0.0.0"
@@ -31,14 +5,17 @@ version = "0.0.0"
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
+categories.workspace = true
+description = "Rust firmware for SlimeVR full-body-tracking"
+keywords = ["slimevr", "full-body-tracking", "vr", "imu", "embassy"]
 
 edition.workspace = true
 rust-version.workspace = true
 
 
 [features]
-# default = ["mcu-esp32c3", "imu-stubbed", "log-rtt", "net-wifi"]
-default = ["mcu-nrf52840", "imu-stubbed", "log-usb-serial", "net-stubbed"]
+default = ["mcu-esp32c3", "imu-stubbed", "log-rtt", "net-wifi"]
+# default = ["mcu-nrf52840", "imu-stubbed", "log-uart", "net-stubbed"]
 # default = ["mcu-esp32", "imu-stubbed", "log-uart", "net-wifi"]
 
 # Supported microcontrollers
@@ -66,7 +43,6 @@ mcu-nrf52840 = [
   "dep:cortex-m",
   "dep:cortex-m-rt",
   "dep:alloc-cortex-m",
-  "dep:embassy-time",
   "dep:embassy-usb",
   "embassy-nrf/nrf52840",
   "embassy-nrf/time-driver-rtc1",
@@ -100,8 +76,9 @@ esp32-hal = { version = "0.7", optional = true, features = [
 
 # mcu-esp32c3 stuff
 esp32c3-hal = { version = "0.4", optional = true, features = [
-  #"embassy",
-  #"embassy-time-systick",
+  "embassy",
+  "embassy-time-timg0",
+  "async",
   #"direct-boot",
 ] }
 riscv-rt = { version = "0.10", optional = true }
@@ -109,7 +86,9 @@ riscv = { version = "0.10", optional = true }
 
 # mcu-nrf52840 stuff
 embassy-nrf = { version = "*", optional = true, default-features = false, features = [
-  "nightly", # For usb
+  "nightly",          # For usb
+  "time",
+  "time-driver-rtc1",
 ] }
 alloc-cortex-m = { version = "0.4", optional = true }
 cortex-m = { version = "0.7", optional = true, features = [
@@ -121,11 +100,10 @@ cortex-m-rt = { version = "0.7", optional = true }
 # Embassy stuff
 embassy-futures = "0.1.0"
 embassy-executor = { version = "*", features = [
-  #"integrated-timers",
+  "integrated-timers",
   "nightly",
 ] }
-embassy-time = { version = "*", optional = true, features = [
-  # "tick-hz-16_000_000",
+embassy-time = { version = "*", features = [
   # "unstable-traits",
 ] }
 embassy-usb = { version = "*", optional = true }
@@ -207,6 +185,11 @@ embassy-nrf = { git = "https://github.com/embassy-rs/embassy", rev = "ebc7350" }
 embassy-usb = { git = "https://github.com/embassy-rs/embassy", rev = "ebc7350" }
 
 
+[profile.dev]
+# lto doesnt work on esp32 (xtensa)
+lto = false
+# opt-level = "s"
+
 # Necessary for esp-wifi to not be bugged
 # https://github.com/esp-rs/esp-wifi/blob/9b644387a54a5ace93d4280f29075ad2a9e9a8ed/README.md#important
 # https://github.com/esp-rs/esp-wifi/issues/88#issuecomment-1332363697
@@ -217,3 +200,26 @@ opt-level = 3
 # https://github.com/esp-rs/xtensa-lx-rt/blob/455d2b77b8a5724d36db0ea66c88467a4515f376/README.md#i-get-linker-errors-when-i-build-for-debug
 [profile.dev.package.xtensa-lx-rt]
 opt-level = 'z'
+
+
+###################
+# Workspace stuff #
+###################
+
+[workspace]
+resolver = "2"
+members = ["crates/panic_defmt", "crates/defmt_esp_println"]
+
+[workspace.package]
+license = "MIT OR Apache-2.0"
+authors = ["Ryan Butler <thebutlah@gmail.com>"]
+repository = "https://github.com/SlimeVR/SlimeVR-Rust"
+categories = ["no-std", "embedded"]
+
+edition = "2021"
+rust-version = "1.65"
+
+[workspace.dependencies]
+esp-println = { version = "0.3", default-features = false, features = [
+  "critical-section", # Necessary because otherwise I'm very sus of the soundness
+] }

--- a/firmware/Embed.toml
+++ b/firmware/Embed.toml
@@ -1,12 +1,12 @@
 ################
 # Default config
 [default.probe]
-# protocol = "Jtag"
-protocol = "Swd"
+protocol = "Jtag" # ESP32*
+# protocol = "Swd" # NRF52*
 
 [default.general]
-# chip = "esp32c3"
-chip = "nrf52840"
+chip = "esp32c3"
+# chip = "nrf52840"
 
 [default.rtt]
 enabled = true

--- a/firmware/Embed.toml
+++ b/firmware/Embed.toml
@@ -1,12 +1,12 @@
 ################
 # Default config
 [default.probe]
-protocol = "Jtag"
-# protocol = "Swd"
+# protocol = "Jtag"
+protocol = "Swd"
 
 [default.general]
-chip = "esp32c3"
-# chip = "nrf52840"
+# chip = "esp32c3"
+chip = "nrf52840"
 
 [default.rtt]
 enabled = true

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -11,6 +11,10 @@ fn main() {
 		esp_xtensa: { any(feature = "mcu-esp32") },
 		esp_riscv: { any(feature = "mcu-esp32c3") },
 		esp: { any(esp_xtensa, esp_riscv) },
+		bbq: { all(
+			feature = "mcu-nrf52840",
+			any(feature = "log-uart", feature = "log-usb-serial")
+		)},
 	}
 
 	#[cfg(all(feature = "net-wifi", feature = "mcu-esp32c3"))]

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -12,9 +12,11 @@ fn main() {
 		esp_riscv: { any(feature = "mcu-esp32c3") },
 		esp: { any(esp_xtensa, esp_riscv) },
 		bbq: { all(
-			feature = "mcu-nrf52840",
+			any(feature = "mcu-nrf52840"),
 			any(feature = "log-uart", feature = "log-usb-serial")
 		)},
+		cortex_m: { any(feature = "mcu-nrf52840") },
+		riscv: { any(feature = "mcu-esp32c3") },
 	}
 
 	#[cfg(all(feature = "net-wifi", feature = "mcu-esp32c3"))]

--- a/firmware/linker_scripts/memory.x.nrf52840
+++ b/firmware/linker_scripts/memory.x.nrf52840
@@ -3,6 +3,9 @@ MEMORY
   /* NOTE K = KiBi = 1024 bytes */
   /* BOOT : ORIGIN = 0x00000000, LENGTH = 4K */
   /* softdevice normally is at 0x1000, but we dont use that so we just write over it */
-  FLASH : ORIGIN = 0x00000000 + 4K, LENGTH = 1M - 4K /* 4K for boot */
+  /*FLASH : ORIGIN = 0x00000000 + 4K, LENGTH = 1M - 4K*/ /* 4K for boot */
+  /* We had to abandon the built in adafruit bootloader because it was messing with the
+     ability to do usb :( */
+  FLASH : ORIGIN = 0x00000000, LENGTH = 1M
   RAM : ORIGIN = 0x20000000, LENGTH = 256K
 }

--- a/firmware/rust-toolchain.toml
+++ b/firmware/rust-toolchain.toml
@@ -1,6 +1,10 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-12-18"
 # channel = "esp" # for when compiling to xtensa targets
-targets = ["riscv32imc-unknown-none-elf", "thumbv7em-none-eabihf", "xtensa-esp32-none-elf"]
+targets = [
+	"riscv32imc-unknown-none-elf",
+	"thumbv7em-none-eabihf",
+	"xtensa-esp32-none-elf",
+]
 profile = "default"
 components = ["llvm-tools-preview", "rust-src", "rustfmt"]

--- a/firmware/src/aliases.rs
+++ b/firmware/src/aliases.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 #[cfg(feature = "mcu-esp32")]
 pub mod ඞ {
 	pub use esp32_hal::ehal;
@@ -34,10 +36,12 @@ pub mod ඞ {
 		embassy_nrf::usb::PowerUsb,
 	>;
 
-	#[cfg(feature = "log-usb-serial")]
+	#[cfg(all(bbq, feature = "log-usb-serial"))]
 	pub type BbqPeripheralConcrete<'a> = UsbDriverConcrete<'a>;
-	#[cfg(feature = "log-uart")]
+	#[cfg(all(bbq, feature = "log-uart"))]
 	pub type BbqPeripheralConcrete<'a> = UartConcrete<'a>;
+	#[cfg(not(bbq))]
+	pub type BbqPeripheralConcrete<'a> = ();
 }
 
 pub trait I2c:

--- a/firmware/src/aliases.rs
+++ b/firmware/src/aliases.rs
@@ -23,6 +23,12 @@ pub mod ඞ {
 
 	pub type UartConcrete<'a> =
 		embassy_nrf::uarte::Uarte<'a, embassy_nrf::peripherals::UARTE0>;
+
+	pub type UsbDriverConcrete<'a> = embassy_nrf::usb::Driver<
+		'a,
+		embassy_nrf::peripherals::USBD,
+		embassy_nrf::usb::PowerUsb,
+	>;
 }
 
 pub trait I2c:

--- a/firmware/src/aliases.rs
+++ b/firmware/src/aliases.rs
@@ -4,6 +4,8 @@ pub mod ඞ {
 	pub use esp32_hal::Delay as DelayConcrete;
 
 	pub type I2cConcrete<'a> = esp32_hal::i2c::I2C<esp32_hal::pac::I2C0>;
+
+	pub type BbqPeripheral<'a> = ();
 }
 
 #[cfg(feature = "mcu-esp32c3")]
@@ -12,6 +14,8 @@ pub mod ඞ {
 	pub use esp32c3_hal::Delay as DelayConcrete;
 
 	pub type I2cConcrete<'a> = esp32c3_hal::i2c::I2C<esp32c3_hal::pac::I2C0>;
+
+	pub type BbqPeripheral<'a> = ();
 }
 
 #[cfg(feature = "mcu-nrf52840")]
@@ -29,6 +33,11 @@ pub mod ඞ {
 		embassy_nrf::peripherals::USBD,
 		embassy_nrf::usb::PowerUsb,
 	>;
+
+	#[cfg(feature = "log-usb-serial")]
+	pub type BbqPeripheralConcrete<'a> = UsbDriverConcrete<'a>;
+	#[cfg(feature = "log-uart")]
+	pub type BbqPeripheralConcrete<'a> = UartConcrete<'a>;
 }
 
 pub trait I2c:

--- a/firmware/src/bbq_logger/embassy_uart.rs
+++ b/firmware/src/bbq_logger/embassy_uart.rs
@@ -1,0 +1,29 @@
+use defmt_bbq::DefmtConsumer;
+use embassy_futures::yield_now;
+use embassy_nrf::uarte::Error;
+
+async fn logger_task(
+	mut bbq: DefmtConsumer,
+	mut uart: crate::aliases::ඞ::UartConcrete<'static>,
+) {
+	debug!("UART logger task!");
+
+	loop {
+		let Ok(grant) = bbq.read() else {
+			yield_now().await;
+			continue;
+		};
+		let len = grant.buf().len();
+		uart.write(b"got data: ").await;
+		match uart.write_from_ram(grant.buf()).await {
+			Err(Error::DMABufferNotInDataMemory) => {
+				// unreachable!("bbq should always be in RAM")
+				()
+			}
+			Err(Error::BufferZeroLength) | Err(Error::BufferTooLong) => (),
+			Ok(()) => (),
+			_ => (),
+		};
+		grant.release(len);
+	}
+}

--- a/firmware/src/bbq_logger/embassy_uart.rs
+++ b/firmware/src/bbq_logger/embassy_uart.rs
@@ -1,8 +1,11 @@
+//! defmt-bbq logger using UART
+
+use defmt::debug;
 use defmt_bbq::DefmtConsumer;
 use embassy_futures::yield_now;
 use embassy_nrf::uarte::Error;
 
-async fn logger_task(
+pub async fn logger_task(
 	mut bbq: DefmtConsumer,
 	mut uart: crate::aliases::ඞ::UartConcrete<'static>,
 ) {
@@ -14,13 +17,13 @@ async fn logger_task(
 			continue;
 		};
 		let len = grant.buf().len();
-		uart.write(b"got data: ").await;
+		let _result = uart.write(b"got data: ").await;
 		match uart.write_from_ram(grant.buf()).await {
 			Err(Error::DMABufferNotInDataMemory) => {
 				// unreachable!("bbq should always be in RAM")
 				()
 			}
-			Err(Error::BufferZeroLength) | Err(Error::BufferTooLong) => (),
+			Err(Error::BufferTooLong) => (),
 			Ok(()) => (),
 			_ => (),
 		};

--- a/firmware/src/bbq_logger/embassy_usb.rs
+++ b/firmware/src/bbq_logger/embassy_usb.rs
@@ -1,3 +1,5 @@
+//! defmt-bbq logger using usb serial + embassy
+
 use defmt::debug;
 use defmt_bbq::DefmtConsumer;
 use embassy_futures::{join::join, yield_now};

--- a/firmware/src/bbq_logger/embassy_usb.rs
+++ b/firmware/src/bbq_logger/embassy_usb.rs
@@ -1,0 +1,94 @@
+use defmt::debug;
+use defmt_bbq::DefmtConsumer;
+use embassy_futures::{join::join, yield_now};
+use embassy_usb::driver::EndpointError;
+
+pub async fn logger_task(
+	mut bbq: DefmtConsumer,
+	driver: crate::aliases::ඞ::UsbDriverConcrete<'static>,
+) {
+	debug!("USB logger task!");
+	// Code based on: https://github.com/embassy-rs/embassy/blob/ebc735008f0b1725b22c944cc5f95fe1aacc665b/examples/nrf/src/bin/usb_serial.rs#L31-L72
+
+	// Create embassy-usb Config
+	let config = {
+		let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+		config.manufacturer = Some("Embassy");
+		config.product = Some("USB-serial example");
+		config.serial_number = Some("12345678");
+		config.max_power = 100;
+		config.max_packet_size_0 = 64;
+
+		// Required for windows compatiblity.
+		// https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
+		config.device_class = 0xEF;
+		config.device_sub_class = 0x02;
+		config.device_protocol = 0x01;
+		config.composite_with_iads = true;
+
+		config
+	};
+
+	// Create embassy-usb DeviceBuilder using the driver and config.
+	// It needs some buffers for building the descriptors.
+	let mut device_descriptor = [0; 256];
+	let mut config_descriptor = [0; 256];
+	let mut bos_descriptor = [0; 256];
+	let mut control_buf = [0; 64];
+
+	let mut state = embassy_usb::class::cdc_acm::State::new();
+
+	let mut builder = embassy_usb::Builder::new(
+		driver,
+		config,
+		&mut device_descriptor,
+		&mut config_descriptor,
+		&mut bos_descriptor,
+		&mut control_buf,
+		None,
+	);
+
+	// Create classes on the builder.
+	let mut usb_class =
+		embassy_usb::class::cdc_acm::CdcAcmClass::new(&mut builder, &mut state, 64);
+
+	// Build the builder.
+	let mut usb_device = builder.build();
+
+	// Future for running the USB device.
+	let usb_fut = usb_device.run();
+
+	let write_fut = async {
+		usb_class.wait_connection().await;
+		debug!("Awaited connection for first time");
+		loop {
+			let Ok(grant) = bbq.read() else {
+				yield_now().await;
+				continue;
+			};
+			let (result, len) = {
+				let buf = grant.buf();
+				let len = buf.len();
+
+				(usb_class.write_packet(buf).await, len)
+			};
+			// TODO: Repeatedly write up to max packet size bytes.
+			match result {
+				Err(EndpointError::BufferOverflow) => {
+					// There was an error, lets ignore it. Don't consume any of the buffer.
+					grant.release(0);
+				}
+				Err(EndpointError::Disabled) => {
+					// There was an error, lets ignore it. Don't consume any of the buffer.
+					grant.release(0);
+					usb_class.wait_connection().await;
+					debug!("Awaited connection");
+				}
+				Ok(()) => grant.release(len),
+			}
+		}
+	};
+
+	// Run everything concurrently
+	join(usb_fut, write_fut).await;
+}

--- a/firmware/src/bbq_logger/mod.rs
+++ b/firmware/src/bbq_logger/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(all(feature = "mcu-nrf52840", feature = "log-uart"))]
+#[path = "embassy_uart.rs"]
+mod ඞ;
+
+#[cfg(all(feature = "mcu-nrf52840", feature = "log-usb-serial"))]
+#[path = "embassy_usb.rs"]
+mod ඞ;
+
+pub use ඞ::logger_task;

--- a/firmware/src/bbq_logger/mod.rs
+++ b/firmware/src/bbq_logger/mod.rs
@@ -1,9 +1,17 @@
-#[cfg(all(feature = "mcu-nrf52840", feature = "log-uart"))]
+//! Implementations for `defmt-bbq` based loggers.
+//!
+//! `defmt-bbq` is a logger that takes any `defmt` logged data and enqueues it in a
+//! special concurrent queue from the `bbqueue` library. We then run an async task to
+//! repeatedly pop from that queue and send that data across some hardware mechanism,
+//! such as USB serial or UART.
+
+#[cfg(not(bbq))]
+compile_error!("This module will only ever be compiled with the `bbq` feature");
+
+#[cfg(all(feature = "log-uart"))]
 #[path = "embassy_uart.rs"]
-mod ඞ;
+pub mod ඞ;
 
-#[cfg(all(feature = "mcu-nrf52840", feature = "log-usb-serial"))]
+#[cfg(all(bbq, feature = "log-usb-serial"))]
 #[path = "embassy_usb.rs"]
-mod ඞ;
-
-pub use ඞ::logger_task;
+pub mod ඞ;

--- a/firmware/src/globals.rs
+++ b/firmware/src/globals.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 #[global_allocator]
 static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 
-#[cfg(feature = "mcu-nrf52840")]
+#[cfg(cortex_m)]
 #[global_allocator]
 static ALLOCATOR: alloc_cortex_m::CortexMHeap = alloc_cortex_m::CortexMHeap::empty();
 

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -1,3 +1,5 @@
+//! An implementation of SlimeVR firmware, written in Rust.
+
 #![no_std]
 #![no_main]
 // Needed for embassy macros
@@ -7,12 +9,14 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 mod aliases;
-mod bbq_logger;
 mod globals;
 mod imu;
 mod networking;
 mod peripherals;
 mod utils;
+
+#[cfg(bbq)]
+mod bbq_logger;
 
 use defmt::debug;
 use embassy_executor::{task, Executor};
@@ -28,10 +32,7 @@ use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {
-	#[cfg(all(
-		feature = "defmt-bbq",
-		any(feature = "log-uart", feature = "log-usb-serial")
-	))]
+	#[cfg(bbq)]
 	let bbq = defmt_bbq::init().unwrap();
 
 	self::globals::setup();
@@ -39,6 +40,7 @@ fn main() -> ! {
 	defmt::trace!("Trace");
 
 	let p = self::peripherals::ඞ::get_peripherals();
+	#[allow(unused)]
 	let (bbq_peripheral, mut p) = p.bbq_peripheral();
 
 	p.delay.delay_ms(500u32);
@@ -48,7 +50,7 @@ fn main() -> ! {
 	EXECUTOR.init(Executor::new()).run(move |spawner| {
 		spawner.spawn(network_task()).unwrap();
 		spawner.spawn(imu_task(p.i2c, p.delay)).unwrap();
-		#[cfg(feature = "defmt-bbq")]
+		#[cfg(bbq)]
 		spawner.spawn(logger_task(bbq, bbq_peripheral)).unwrap();
 	});
 }
@@ -67,11 +69,11 @@ async fn imu_task(
 	crate::imu::imu_task(i2c, delay).await
 }
 
-#[cfg(feature = "defmt-bbq")]
+#[cfg(bbq)]
 #[task]
 async fn logger_task(
 	bbq: defmt_bbq::DefmtConsumer,
 	logger_peripheral: crate::aliases::ඞ::BbqPeripheralConcrete<'static>,
 ) {
-	crate::bbq_logger::logger_task(bbq, logger_peripheral).await;
+	crate::bbq_logger::ඞ::logger_task(bbq, logger_peripheral).await;
 }

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -7,6 +7,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 mod aliases;
+mod bbq_logger;
 mod globals;
 mod imu;
 mod networking;
@@ -37,7 +38,9 @@ fn main() -> ! {
 	debug!("Booted");
 	defmt::trace!("Trace");
 
-	let mut p = self::peripherals::ඞ::get_peripherals();
+	let p = self::peripherals::ඞ::get_peripherals();
+	let (bbq_peripheral, mut p) = p.bbq_peripheral();
+
 	p.delay.delay_ms(500u32);
 	debug!("Initialized peripherals");
 
@@ -45,10 +48,8 @@ fn main() -> ! {
 	EXECUTOR.init(Executor::new()).run(move |spawner| {
 		spawner.spawn(network_task()).unwrap();
 		spawner.spawn(imu_task(p.i2c, p.delay)).unwrap();
-		#[cfg(all(feature = "defmt-bbq", feature = "log-uart"))]
-		spawner.spawn(logger_task(bbq, p.uart)).unwrap();
-		#[cfg(all(feature = "mcu-nrf52840", feature = "log-usb-serial"))]
-		spawner.spawn(logger_task(bbq, p.usb_driver)).unwrap()
+		#[cfg(feature = "defmt-bbq")]
+		spawner.spawn(logger_task(bbq, bbq_peripheral)).unwrap();
 	});
 }
 
@@ -62,132 +63,15 @@ async fn imu_task(
 	i2c: crate::aliases::ඞ::I2cConcrete<'static>,
 	delay: crate::aliases::ඞ::DelayConcrete,
 ) {
+	debug!("IMU Task!");
 	crate::imu::imu_task(i2c, delay).await
 }
 
-#[cfg(all(feature = "log-uart", feature = "mcu-nrf52840", feature = "defmt-bbq"))]
+#[cfg(feature = "defmt-bbq")]
 #[task]
 async fn logger_task(
-	mut bbq: defmt_bbq::DefmtConsumer,
-	mut uart: crate::aliases::ඞ::UartConcrete<'static>,
+	bbq: defmt_bbq::DefmtConsumer,
+	logger_peripheral: crate::aliases::ඞ::BbqPeripheralConcrete<'static>,
 ) {
-	use embassy_futures::yield_now;
-	use embassy_nrf::uarte::Error;
-
-	loop {
-		let Ok(grant) = bbq.read() else {
-			yield_now().await;
-			continue;
-		};
-		let len = grant.buf().len();
-		uart.write(b"got data: ").await;
-		match uart.write_from_ram(grant.buf()).await {
-			Err(Error::DMABufferNotInDataMemory) => {
-				// unreachable!("bbq should always be in RAM")
-				()
-			}
-			Err(Error::BufferZeroLength) | Err(Error::BufferTooLong) => (),
-			Ok(()) => (),
-			_ => (),
-		};
-		grant.release(len);
-	}
-}
-
-#[cfg(all(feature = "log-usb-serial", feature = "mcu-nrf52840",))]
-#[task]
-async fn logger_task(
-	mut bbq: defmt_bbq::DefmtConsumer,
-	driver: crate::aliases::ඞ::UsbDriverConcrete<'static>,
-) {
-	use embassy_futures::{join::join, yield_now};
-
-	debug!("Entered usb logger task");
-	// Code based on: https://github.com/embassy-rs/embassy/blob/ebc735008f0b1725b22c944cc5f95fe1aacc665b/examples/nrf/src/bin/usb_serial.rs#L31-L72
-
-	// Create embassy-usb Config
-	let config = {
-		let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-		config.manufacturer = Some("Embassy");
-		config.product = Some("USB-serial example");
-		config.serial_number = Some("12345678");
-		config.max_power = 100;
-		config.max_packet_size_0 = 64;
-
-		// Required for windows compatiblity.
-		// https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
-		config.device_class = 0xEF;
-		config.device_sub_class = 0x02;
-		config.device_protocol = 0x01;
-		config.composite_with_iads = true;
-
-		config
-	};
-
-	debug!("Created config");
-
-	// Create embassy-usb DeviceBuilder using the driver and config.
-	// It needs some buffers for building the descriptors.
-	let mut device_descriptor = [0; 256];
-	let mut config_descriptor = [0; 256];
-	let mut bos_descriptor = [0; 256];
-	let mut control_buf = [0; 64];
-
-	let mut state = embassy_usb::class::cdc_acm::State::new();
-	debug!("State");
-
-	let mut builder = embassy_usb::Builder::new(
-		driver,
-		config,
-		&mut device_descriptor,
-		&mut config_descriptor,
-		&mut bos_descriptor,
-		&mut control_buf,
-		None,
-	);
-
-	// Create classes on the builder.
-	let mut usb_class =
-		embassy_usb::class::cdc_acm::CdcAcmClass::new(&mut builder, &mut state, 64);
-
-	debug!("usb class");
-
-	// Build the builder.
-	let mut usb_device = builder.build();
-	debug!("usb device");
-
-	// Future for running the USB device.
-	let usb_fut = usb_device.run();
-
-	let write_fut = async {
-		loop {
-			usb_class.wait_connection().await;
-			debug!("Awaited connection");
-			let Ok(grant) = bbq.read() else {
-				yield_now().await;
-				continue;
-			};
-			let (result, len) = {
-				let buf = grant.buf();
-				let len = buf.len();
-
-				(usb_class.write_packet(buf).await, len)
-			};
-			// let buf = b"hello";
-			// TODO: Repeatedly write up to max packet size bytes.
-			if let Err(_err) = result {
-				// defmt::error!("{}", defmt::Debug2Format(&err));
-				// There was an error, lets ignore it. Don't consume any of the buffer.
-				grant.release(0);
-			} else {
-				grant.release(len);
-				// defmt::debug!("Printed buf");
-			}
-		}
-	};
-
-	debug!("about to start future");
-
-	// Run everything concurrently
-	join(usb_fut, write_fut).await;
+	crate::bbq_logger::logger_task(bbq, logger_peripheral).await;
 }

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -35,6 +35,7 @@ fn main() -> ! {
 
 	self::globals::setup();
 	debug!("Booted");
+	defmt::trace!("Trace");
 
 	let mut p = self::peripherals::ඞ::get_peripherals();
 	p.delay.delay_ms(500u32);
@@ -46,6 +47,8 @@ fn main() -> ! {
 		spawner.spawn(imu_task(p.i2c, p.delay)).unwrap();
 		#[cfg(all(feature = "defmt-bbq", feature = "log-uart"))]
 		spawner.spawn(logger_task(bbq, p.uart)).unwrap();
+		#[cfg(all(feature = "mcu-nrf52840", feature = "log-usb-serial"))]
+		spawner.spawn(logger_task(/*bbq,*/ p.usb_driver)).unwrap()
 	});
 }
 
@@ -74,7 +77,7 @@ async fn logger_task(
 	loop {
 		let Ok(grant) = bbq.read() else {
 			yield_now().await;
-			continue; //should be impossible	
+			continue;
 		};
 		let len = grant.buf().len();
 		uart.write(b"got data: ").await;
@@ -89,4 +92,102 @@ async fn logger_task(
 		};
 		grant.release(len);
 	}
+}
+
+#[cfg(all(
+	// feature = "log-usb-serial",
+	feature = "log-rtt",
+	feature = "mcu-nrf52840",
+	// feature = "defmt-bbq"
+))]
+#[task]
+async fn logger_task(
+	// mut bbq: defmt_bbq::DefmtConsumer,
+	driver: crate::aliases::ඞ::UsbDriverConcrete<'static>,
+) {
+	use embassy_futures::{join::join, yield_now};
+
+	debug!("Entered usb logger task");
+	// Code based on: https://github.com/embassy-rs/embassy/blob/ebc735008f0b1725b22c944cc5f95fe1aacc665b/examples/nrf/src/bin/usb_serial.rs#L31-L72
+
+	// Create embassy-usb Config
+	let config = {
+		let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+		config.manufacturer = Some("Embassy");
+		config.product = Some("USB-serial example");
+		config.serial_number = Some("12345678");
+		config.max_power = 100;
+		config.max_packet_size_0 = 64;
+
+		// Required for windows compatiblity.
+		// https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
+		config.device_class = 0xEF;
+		config.device_sub_class = 0x02;
+		config.device_protocol = 0x01;
+		config.composite_with_iads = true;
+
+		config
+	};
+
+	debug!("Created config");
+
+	// Create embassy-usb DeviceBuilder using the driver and config.
+	// It needs some buffers for building the descriptors.
+	let mut device_descriptor = [0; 256];
+	let mut config_descriptor = [0; 256];
+	let mut bos_descriptor = [0; 256];
+	let mut control_buf = [0; 64];
+
+	let mut state = embassy_usb::class::cdc_acm::State::new();
+	debug!("State");
+
+	let mut builder = embassy_usb::Builder::new(
+		driver,
+		config,
+		&mut device_descriptor,
+		&mut config_descriptor,
+		&mut bos_descriptor,
+		&mut control_buf,
+		None,
+	);
+
+	// Create classes on the builder.
+	let mut usb_class =
+		embassy_usb::class::cdc_acm::CdcAcmClass::new(&mut builder, &mut state, 64);
+
+	debug!("usb class");
+
+	// Build the builder.
+	let mut usb_device = builder.build();
+	debug!("usb device");
+
+	// Future for running the USB device.
+	let usb_fut = usb_device.run();
+
+	let write_fut = async {
+		loop {
+			usb_class.wait_connection().await;
+			debug!("Awaited connection");
+			// let Ok(grant) = bbq.read() else {
+			// 	yield_now().await;
+			// 	continue;
+			// };
+			// let buf = grant.buf();
+			let buf = b"hello";
+			// TODO: Repeatedly write up to max packet size bytes.
+			if let Err(err) = usb_class.write_packet(buf).await {
+				defmt::error!("{}", defmt::Debug2Format(&err));
+			// There was an error, lets ignore it. Don't consume any of the buffer.
+			// grant.release(0);
+			} else {
+				// grant.release(buf.len());
+				defmt::debug!("Printed buf");
+			}
+		}
+	};
+
+	debug!("about to start future");
+
+	// Run everything concurrently
+	join(usb_fut, write_fut).await;
 }

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -23,9 +23,9 @@ use embassy_executor::{task, Executor};
 use embedded_hal::blocking::delay::DelayMs;
 use static_cell::StaticCell;
 
-#[cfg(feature = "mcu-nrf52840")]
+#[cfg(cortex_m)]
 use cortex_m_rt::entry;
-#[cfg(target_arch = "riscv32")]
+#[cfg(riscv)]
 use riscv_rt::entry;
 #[cfg(esp_xtensa)]
 use xtensa_lx_rt::entry;

--- a/firmware/src/networking/mod.rs
+++ b/firmware/src/networking/mod.rs
@@ -16,6 +16,6 @@ pub async fn stubbed_network_task() {
 
 	loop {
 		defmt::debug!("pretending to do networking..");
-		embassy_time::Timer::after(Duration::from_secs(1)).await
+		embassy_time::Timer::after(Duration::from_secs(5)).await
 	}
 }

--- a/firmware/src/networking/mod.rs
+++ b/firmware/src/networking/mod.rs
@@ -1,3 +1,5 @@
+use embassy_time::Duration;
+
 #[cfg(feature = "net-wifi")]
 pub mod wifi;
 
@@ -11,4 +13,9 @@ pub async fn network_task() {
 /// This does nothing, its a "fake" networking task meant to facilitate testing and
 /// the initial port to a new platform (because there are no networking dependencies).
 #[allow(dead_code)]
-pub async fn stubbed_network_task() {}
+pub async fn stubbed_network_task() {
+	loop {
+		defmt::debug!("pretending to do networking..");
+		embassy_time::Timer::after(Duration::from_secs(1)).await
+	}
+}

--- a/firmware/src/networking/mod.rs
+++ b/firmware/src/networking/mod.rs
@@ -1,5 +1,3 @@
-use embassy_time::Duration;
-
 #[cfg(feature = "net-wifi")]
 pub mod wifi;
 
@@ -14,6 +12,8 @@ pub async fn network_task() {
 /// the initial port to a new platform (because there are no networking dependencies).
 #[allow(dead_code)]
 pub async fn stubbed_network_task() {
+	use embassy_time::Duration;
+
 	loop {
 		defmt::debug!("pretending to do networking..");
 		embassy_time::Timer::after(Duration::from_secs(1)).await

--- a/firmware/src/peripherals/esp32c3.rs
+++ b/firmware/src/peripherals/esp32c3.rs
@@ -22,7 +22,7 @@ pub fn get_peripherals() -> Peripherals<I2cConcrete<'static>, DelayConcrete> {
 	// embassy::init(&clocks);
 
 	// Disable the RTC and TIMG watchdog timers
-	{
+	let timer0 = {
 		let mut rtc = Rtc::new(p.RTC_CNTL);
 		let timer_group0 = TimerGroup::new(p.TIMG0, &clocks);
 		let mut wdt0 = timer_group0.wdt;
@@ -33,7 +33,12 @@ pub fn get_peripherals() -> Peripherals<I2cConcrete<'static>, DelayConcrete> {
 		rtc.swd.disable();
 		wdt0.disable();
 		wdt1.disable();
-	}
+
+		timer_group0.timer0
+	};
+
+	// Initialize embassy
+	esp32c3_hal::embassy::init(&clocks, timer0);
 
 	// Initialize esp-wifi stuff
 	#[cfg(feature = "net-wifi")]

--- a/firmware/src/peripherals/mod.rs
+++ b/firmware/src/peripherals/mod.rs
@@ -73,7 +73,7 @@ impl<I2c, Delay, Uart, UsbDriver> Peripherals<I2c, Delay, Uart, UsbDriver> {
 
 /// Type-level destructors for `Peripherals` which turn peripheral type into ().
 impl<I2c, Delay, Uart, UsbDriver> Peripherals<I2c, Delay, Uart, UsbDriver> {
-	#[cfg(feature = "log-usb-serial")]
+	#[cfg(all(bbq, feature = "log-usb-serial"))]
 	pub fn bbq_peripheral(self) -> (UsbDriver, Peripherals<I2c, Delay, Uart, ()>) {
 		(
 			self.usb_driver,
@@ -85,8 +85,8 @@ impl<I2c, Delay, Uart, UsbDriver> Peripherals<I2c, Delay, Uart, UsbDriver> {
 			},
 		)
 	}
-	#[cfg(feature = "log-uart")]
-	pub fn bbq_peripheral(self) -> (UsbDriver, Peripherals<I2c, Delay, (), UsbDriver>) {
+	#[cfg(all(bbq, feature = "log-uart"))]
+	pub fn bbq_peripheral(self) -> (Uart, Peripherals<I2c, Delay, (), UsbDriver>) {
 		(
 			self.uart,
 			Peripherals {
@@ -96,5 +96,9 @@ impl<I2c, Delay, Uart, UsbDriver> Peripherals<I2c, Delay, Uart, UsbDriver> {
 				usb_driver: self.usb_driver,
 			},
 		)
+	}
+	#[cfg(not(bbq))]
+	pub fn bbq_peripheral(self) -> ((), Peripherals<I2c, Delay, Uart, UsbDriver>) {
+		((), self)
 	}
 }

--- a/firmware/src/peripherals/mod.rs
+++ b/firmware/src/peripherals/mod.rs
@@ -30,6 +30,8 @@ impl Peripherals {
 		}
 	}
 }
+/// Type-level builder for `Peripherals`, which transforms each field from () to the
+/// peripheral type.
 impl<I2c, Delay, Uart, UsbDriver> Peripherals<I2c, Delay, Uart, UsbDriver> {
 	#[allow(dead_code)]
 	pub fn i2c<T>(self, p: T) -> Peripherals<T, Delay, Uart, UsbDriver> {
@@ -66,5 +68,33 @@ impl<I2c, Delay, Uart, UsbDriver> Peripherals<I2c, Delay, Uart, UsbDriver> {
 			uart: self.uart,
 			usb_driver: p,
 		}
+	}
+}
+
+/// Type-level destructors for `Peripherals` which turn peripheral type into ().
+impl<I2c, Delay, Uart, UsbDriver> Peripherals<I2c, Delay, Uart, UsbDriver> {
+	#[cfg(feature = "log-usb-serial")]
+	pub fn bbq_peripheral(self) -> (UsbDriver, Peripherals<I2c, Delay, Uart, ()>) {
+		(
+			self.usb_driver,
+			Peripherals {
+				i2c: self.i2c,
+				delay: self.delay,
+				uart: self.uart,
+				usb_driver: (),
+			},
+		)
+	}
+	#[cfg(feature = "log-uart")]
+	pub fn bbq_peripheral(self) -> (UsbDriver, Peripherals<I2c, Delay, (), UsbDriver>) {
+		(
+			self.uart,
+			Peripherals {
+				i2c: self.i2c,
+				delay: self.delay,
+				uart: (),
+				usb_driver: self.usb_driver,
+			},
+		)
 	}
 }

--- a/firmware/src/peripherals/mod.rs
+++ b/firmware/src/peripherals/mod.rs
@@ -14,10 +14,11 @@ pub mod ඞ;
 
 /// Holds the peripherals. This merely exists to allow a way to pass around platform
 /// specific peripherals, some of which may not even exist, in a platform-agnostic way.
-pub struct Peripherals<I2c = (), Delay = (), Uart = ()> {
+pub struct Peripherals<I2c = (), Delay = (), Uart = (), UsbDriver = ()> {
 	pub i2c: I2c,
 	pub delay: Delay,
 	pub uart: Uart,
+	pub usb_driver: UsbDriver,
 }
 impl Peripherals {
 	pub fn new() -> Self {
@@ -25,32 +26,45 @@ impl Peripherals {
 			i2c: (),
 			delay: (),
 			uart: (),
+			usb_driver: (),
 		}
 	}
 }
-impl<I2c, Delay, Uart> Peripherals<I2c, Delay, Uart> {
+impl<I2c, Delay, Uart, UsbDriver> Peripherals<I2c, Delay, Uart, UsbDriver> {
 	#[allow(dead_code)]
-	pub fn i2c<N>(self, p: N) -> Peripherals<N, Delay, Uart> {
+	pub fn i2c<T>(self, p: T) -> Peripherals<T, Delay, Uart, UsbDriver> {
 		Peripherals {
 			i2c: p,
 			delay: self.delay,
 			uart: self.uart,
+			usb_driver: self.usb_driver,
 		}
 	}
 	#[allow(dead_code)]
-	pub fn delay<N>(self, p: N) -> Peripherals<I2c, N, Uart> {
+	pub fn delay<T>(self, p: T) -> Peripherals<I2c, T, Uart, UsbDriver> {
 		Peripherals {
 			i2c: self.i2c,
 			delay: p,
 			uart: self.uart,
+			usb_driver: self.usb_driver,
 		}
 	}
 	#[allow(dead_code)]
-	pub fn uart<N>(self, p: N) -> Peripherals<I2c, Delay, N> {
+	pub fn uart<T>(self, p: T) -> Peripherals<I2c, Delay, T, UsbDriver> {
 		Peripherals {
 			i2c: self.i2c,
 			delay: self.delay,
 			uart: p,
+			usb_driver: self.usb_driver,
+		}
+	}
+	#[allow(dead_code)]
+	pub fn usb_driver<T>(self, p: T) -> Peripherals<I2c, Delay, Uart, T> {
+		Peripherals {
+			i2c: self.i2c,
+			delay: self.delay,
+			uart: self.uart,
+			usb_driver: p,
 		}
 	}
 }

--- a/firmware/src/peripherals/nrf52840.rs
+++ b/firmware/src/peripherals/nrf52840.rs
@@ -2,14 +2,20 @@ use super::Peripherals;
 use crate::aliases::ඞ::DelayConcrete;
 use crate::aliases::ඞ::I2cConcrete;
 use crate::aliases::ඞ::UartConcrete;
+use crate::aliases::ඞ::UsbDriverConcrete;
 
 use defmt::debug;
 use embassy_nrf::interrupt;
 use embassy_nrf::twim::{self, Twim};
 use embassy_nrf::uarte::{self, Uarte};
+use embassy_nrf::usb::{self, Driver};
 
-pub fn get_peripherals(
-) -> Peripherals<I2cConcrete<'static>, DelayConcrete, UartConcrete<'static>> {
+pub fn get_peripherals() -> Peripherals<
+	I2cConcrete<'static>,
+	DelayConcrete,
+	UartConcrete<'static>,
+	UsbDriverConcrete<'static>,
+> {
 	let p = embassy_nrf::init(Default::default());
 	debug!("Initializing TWIM (I2C controller)");
 
@@ -20,8 +26,10 @@ pub fn get_peripherals(
 		let irq = interrupt::take!(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0);
 		Twim::new(p.TWISPI0, irq, p.P0_03, p.P0_04, config)
 	};
+	debug!("Initialized twim");
 
 	let delay = embassy_time::Delay;
+	debug!("Initialized delay");
 
 	let uarte = {
 		let irq = interrupt::take!(UARTE0_UART0);
@@ -32,7 +40,15 @@ pub fn get_peripherals(
 		let tx = p.P1_11;
 		Uarte::new(p.UARTE0, irq, rx, tx, config)
 	};
+	debug!("Initialized uarte");
+
+	let usb_driver = {
+		let irq = interrupt::take!(USBD);
+		let power_irq = interrupt::take!(POWER_CLOCK);
+		Driver::new(p.USBD, irq, usb::PowerUsb::new(power_irq))
+	};
+	debug!("Initialized usb_driver");
 
 	let p = Peripherals::new();
-	p.i2c(twim).delay(delay).uart(uarte)
+	p.i2c(twim).delay(delay).uart(uarte).usb_driver(usb_driver)
 }


### PR DESCRIPTION
For some reason this doesn't work with normal serial monitors, but if you `cat` the `/dev/cu.usb6969` it works.