### PR TITLE
overlay: Switch to standing universe, which is "close enough"

### DIFF
--- a/overlay/src/model/bone.rs
+++ b/overlay/src/model/bone.rs
@@ -136,7 +136,7 @@ impl Bone {
 				let col_major_3x4 = Matrix3x4::from(&transform);
 				mngr.set_transform_absolute(
 					overlay,
-					TrackingUniverseOrigin::TrackingUniverseRawAndUncalibrated,
+					TrackingUniverseOrigin::TrackingUniverseStanding,
 					&col_major_3x4,
 				)
 				.wrap_err("Failed to set transform")?;


### PR DESCRIPTION
Driver and Feeder now use a "static standing" universe, which should be the same as standing universe except it ignores playspace changing.

Ideally, we'd implement that here too, but this is better than leaving it the way it is. When playspace movement happens, I expect the skeleton to move relative to the player.

For future reference, this is how I handled it in feeder app: https://github.com/SlimeVR/SlimeVR-Feeder-App/blob/master/src/main.cpp#L660-L700