### PR TITLE
Fixed wrong linkage and ApProtect

### DIFF
--- a/firmware/.cargo/config.toml
+++ b/firmware/.cargo/config.toml
@@ -55,7 +55,7 @@ rustflags = [
   # For cortex-m-rt
   "-C",
   "link-arg=-Tlink.x",
-  # For defmt 
+  # For defmt
   "-C",
   "link-arg=-Tdefmt.x",
 ]

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 
 [features]
 default = ["mcu-esp32c3", "imu-stubbed", "log-rtt", "net-wifi"]
-# default = ["mcu-nrf52840", "imu-stubbed", "log-usb-serial", "net-stubbed"]
+# default = ["mcu-nrf52840", "imu-stubbed", "log-rtt", "net-stubbed"]
 # default = ["mcu-esp32", "imu-stubbed", "log-uart", "net-wifi"]
 
 # Supported microcontrollers

--- a/firmware/Embed.toml
+++ b/firmware/Embed.toml
@@ -40,7 +40,7 @@ enabled = false
 ################
 # This fixes rtt logs from not showing up. Run it once.
 [fixrtt.reset]
-halt_afterwards = true # This is the magic sauce, but WHY? 
+halt_afterwards = true # This is the magic sauce, but WHY?
 
 [fixrtt.gdb]
 enabled = false

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -80,19 +80,27 @@ struct SoftdeviceInfo {
 #[allow(dead_code)]
 impl SoftdeviceInfo {
 	const NONE: SoftdeviceInfo = SoftdeviceInfo {
-		mbr_size: 0x1000,
+		mbr_size: 0x0,
 		sd_flash_size: 0x0,
 		sd_ram_size: 0x0,
+	};
+	/// Uses the Master Boot Record, but not softdevice
+	const MBR_ONLY: SoftdeviceInfo = SoftdeviceInfo {
+		mbr_size: 0x1000,
+		sd_flash_size: 0x0,
+		// TODO: Is this correct? Disabling softdevice requires 8 bytes, but idk what
+		// should happen if softdevice is entirely overwritten with our firmware.
+		sd_ram_size: 0x8,
 	};
 	const S140: SoftdeviceInfo = SoftdeviceInfo {
 		mbr_size: 0x1000,
 		sd_flash_size: 0x26000,
-		sd_ram_size: 0x0,
+		sd_ram_size: 0x8,
 	};
 	const S132: SoftdeviceInfo = SoftdeviceInfo {
 		mbr_size: 0x1000,
 		sd_flash_size: 0x25000,
-		sd_ram_size: 0x0,
+		sd_ram_size: 0x8,
 	};
 	// TODO: Support other softdevice versions
 }

--- a/firmware/src/globals.rs
+++ b/firmware/src/globals.rs
@@ -37,7 +37,7 @@ pub fn setup() {
 	// disables writing and reading the flash.
 	// More info on the register:
 	// https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/uicr.html
-	#[cfg(mcu_f_nrf52)]
+	#[cfg(mcu_f_nrf52_babback_ombamba)] // TODO: Get this working with softdevice.
 	unsafe {
 		#[cfg(feature = "mcu-nrf52832")]
 		use nrf52832_pac as pac;


### PR DESCRIPTION
We merged code in #125 that started modifying ApProtect, but this didn't actually work consistently across devices. Not sure why, probably had to do with the fact that we weren't actually using softdevice but still had the MBR.

I've changed the code to fully overwrite not just softdevice but the MBR too, and stop trying to mess with ApProtect. When we actually go back and add softdevice properly, we can try to re-grapple with this.