### PR TITLE
Add clientbound handshake response packet

### DIFF
--- a/networking/firmware_protocol/src/clientbound.rs
+++ b/networking/firmware_protocol/src/clientbound.rs
@@ -13,6 +13,12 @@ pub enum CbPacket {
 		/// Arbitrary bytes sent by the server that must be echoed
 		challenge: [u8; 4],
 	},
+	/// u32::from_be_bytes([3, 'H' as u8, 'e' as u8, 'y' as u8]) -> 55076217
+	#[deku(id = "55076217")]
+	HandshakeResponse {
+		/// Char. SlimeVR Server sends '5' = 53
+		version: u8,
+	},
 }
 
 #[cfg(test)]
@@ -44,5 +50,20 @@ mod tests {
 			},
 			&[1, 2, 3, 4],
 		);
+	}
+
+	#[test]
+	fn handshake_response() {
+		// 3"Hey" -> [3, 72, 101, 121] -> 55076217
+		// " OVR =D " -> [32, 79, 86, 82, 32, 61, 68, 32]
+		// u64::from_be_bytes([32, 79, 86, 82, 32, 61, 68, 32]) -> 2328174443102028832
+		let packet = Packet::new(
+			2_328_174_443_102_028_832,
+			CbPacket::HandshakeResponse { version: '5' as u8 },
+		)
+		.to_bytes()
+		.unwrap();
+
+		assert_eq!(&packet, &"\x03Hey OVR =D 5".as_bytes());
 	}
 }

--- a/networking/firmware_protocol/src/clientbound.rs
+++ b/networking/firmware_protocol/src/clientbound.rs
@@ -13,7 +13,7 @@ pub enum CbPacket {
 		/// Arbitrary bytes sent by the server that must be echoed
 		challenge: [u8; 4],
 	},
-	/// u32::from_be_bytes([3, 'H' as u8, 'e' as u8, 'y' as u8]) -> 55076217
+	/// u32::from_be_bytes([3, b'H', b'e', b'y']) -> 55076217
 	#[deku(id = "55076217")]
 	HandshakeResponse {
 		/// Char. SlimeVR Server sends '5' = 53
@@ -59,7 +59,7 @@ mod tests {
 		// u64::from_be_bytes([32, 79, 86, 82, 32, 61, 68, 32]) -> 2328174443102028832
 		let packet = Packet::new(
 			2_328_174_443_102_028_832,
-			CbPacket::HandshakeResponse { version: '5' as u8 },
+			CbPacket::HandshakeResponse { version: b'5' },
 		)
 		.to_bytes()
 		.unwrap();


### PR DESCRIPTION
I'm unsure if this is the way we want to implement this.
The response is unlike any other packet, so it needs some special handling.
We're kinda "lucky" that "\x03Hey OVR =D 5" fits nicely as:
* u32 id (3"Hey")
* u64 sequence (" OVR =D ")
* u8 for the version ("5")

Doing it this way works but feels very hacky?