### PR TITLE
Add basic BLE advertising stub for ESP32

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -161,6 +161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bleps"
+version = "0.1.0"
+source = "git+https://github.com/bjoernQ/bleps?rev=06e1f7b#06e1f7b3810b7271d1004635842b691adaea4818"
+dependencies = [
+ "embedded-io 0.3.1",
+ "log",
+]
+
+[[package]]
 name = "bmi160"
 version = "0.1.0"
 source = "git+https://github.com/TheButlah/bmi160-rs?rev=e99802b#e99802b801f36509bb769a6646153f0a77ba49c5"
@@ -790,7 +799,7 @@ dependencies = [
 [[package]]
 name = "esp-wifi"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-wifi.git?rev=aa850de#aa850de8e74d5e37addb67b3a66be35ea58029f9"
+source = "git+https://github.com/esp-rs/esp-wifi.git?rev=d478a81#d478a81cd13507365b6885d8f8d29c9e56882b89"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "critical-section",
@@ -889,6 +898,7 @@ name = "firmware"
 version = "0.0.0"
 dependencies = [
  "alloc-cortex-m",
+ "bleps",
  "bmi160",
  "cfg_aliases",
  "color-eyre",

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -60,7 +60,8 @@ mcu-nrf52832 = [
 ]
 
 # Wi-fi dependencies
-net-wifi = ["dep:esp-wifi", "dep:smoltcp"] # use wifi
+net-wifi = ["esp-wifi/wifi", "dep:smoltcp"] # use wifi
+net-ble = ["esp-wifi/ble", "dep:bleps"]
 net-stubbed = []                           # Stubs out network
 
 # Supported IMUs
@@ -148,8 +149,7 @@ esp-alloc = { version = "0.1", optional = true }
 defmt_esp_println = { path = "crates/defmt_esp_println", optional = true }
 
 # Wi-Fi
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", rev = "aa850de", features = [
-  "wifi",
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", rev = "d478a81", features = [
   "embedded-svc",
 ], optional = true }
 smoltcp = { version = "0.8", default-features = false, features = [
@@ -165,6 +165,9 @@ smoltcp = { version = "0.8", default-features = false, features = [
   "proto-igmp",
   "proto-ipv4",
 ], optional = true }
+
+# Generic BLE
+bleps = { git = "https://github.com/bjoernQ/bleps", rev = "06e1f7b", optional = true }
 
 # nrf ble
 nrf-softdevice = { version = "*", default-features = false, features = [

--- a/firmware/build.rs
+++ b/firmware/build.rs
@@ -10,7 +10,7 @@ use std::{
 mandatory_and_unique!("mcu-esp32", "mcu-esp32c3", "mcu-nrf52832", "mcu-nrf52840");
 mandatory_and_unique!("imu-stubbed", "imu-mpu6050", "imu-bmi160");
 mandatory_and_unique!("log-rtt", "log-usb-serial", "log-uart");
-mandatory_and_unique!("net-wifi", "net-stubbed");
+mandatory_and_unique!("net-wifi", "net-ble", "net-stubbed");
 
 #[cfg(any(feature = "mcu-nrf52840", feature = "mcu-nrf52832"))]
 mandatory_and_unique!(
@@ -50,10 +50,11 @@ fn main() -> Result<()> {
 		riscv: { any(feature = "mcu-esp32c3") },
 	}
 
-	#[cfg(all(feature = "net-wifi", feature = "mcu-esp32c3"))]
-	println!("cargo:rustc-link-arg=-Tesp32c3_rom_functions.x"); // esp-wifi
-	#[cfg(all(feature = "net-wifi", feature = "mcu-esp32"))]
-	println!("cargo:rustc-link-arg=-Tesp32_rom_functions.x"); // esp-wifi
+	// Link into Espressif's radio driver blobs
+	#[cfg(all(feature = "esp-wifi", feature = "mcu-esp32c3"))]
+	println!("cargo:rustc-link-arg=-Tesp32c3_rom_functions.x");
+	#[cfg(all(feature = "esp-wifi", feature = "mcu-esp32"))]
+	println!("cargo:rustc-link-arg=-Tesp32_rom_functions.x");
 
 	// By default, Cargo will re-run a build script whenever
 	// any file in the project changes. By specifying `memory.x`

--- a/firmware/src/networking/ble/esp.rs
+++ b/firmware/src/networking/ble/esp.rs
@@ -1,0 +1,49 @@
+use crate::networking::Packets;
+use bleps::{
+	ad_structure::{
+		create_advertising_data, AdStructure, BR_EDR_NOT_SUPPORTED,
+		LE_GENERAL_DISCOVERABLE,
+	},
+	Ble, Data, HciConnector,
+};
+use defmt::trace;
+use embassy_futures::yield_now;
+use esp_wifi::{self, ble::controller::BleConnector, current_millis};
+
+pub async fn network_task(packets: &Packets) -> ! {
+	// HCI is the host-controller interface, which lets the MCU communicate to the BLE hardware through a standard
+	// command interface
+	let connector = BleConnector {};
+	let hci = HciConnector::new(connector, current_millis);
+	let mut ble = Ble::new(&hci);
+
+	ble.init().expect("Failed to initialize BLE hardware");
+
+	// This will configure settings for the advertising server, like interval rate
+	ble.cmd_set_le_advertising_parameters()
+		.expect("Failed to configure advertising");
+
+	ble.cmd_set_le_advertising_data(create_advertising_data(&[
+		// Public advertising and and we do not support full Bluetooth connection (basic rate/extended data rate)
+		AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+		AdStructure::CompleteLocalName("SlimeVR-Rust"),
+		// Placeholder for SlimeVR advertised quaternion data. BLE advertising data size is tight, we should consider a
+		// quantized quaternion format. 64 or even 32 bits should be enough
+		// TODO: Unimplemented
+		// AdStructure::ManufacturerSpecificData {
+		// 	company_identifier: 0,
+		// 	payload: &[0; 16],
+		// },
+	]))
+	.expect("Failed to set advertising data");
+
+	ble.cmd_set_le_advertise_enable(true)
+		.expect("Failed to start advertising");
+
+	loop {
+		yield_now().await;
+		let Some(event) = ble.poll() else { continue };
+
+		trace!("BLE: {}", event);
+	}
+}

--- a/firmware/src/networking/ble/mod.rs
+++ b/firmware/src/networking/ble/mod.rs
@@ -1,0 +1,3 @@
+#[cfg(feature = "net-ble")]
+#[path = "esp.rs"]
+pub mod ඞ;

--- a/firmware/src/networking/mod.rs
+++ b/firmware/src/networking/mod.rs
@@ -2,6 +2,9 @@ pub mod protocol;
 #[cfg(feature = "net-wifi")]
 pub mod wifi;
 
+#[cfg(feature = "net-ble")]
+pub mod ble;
+
 use defmt::debug;
 use embassy_executor::task;
 
@@ -12,6 +15,8 @@ pub async fn network_task(msg_signals: &'static Packets) {
 	debug!("Network task");
 	#[cfg(feature = "net-wifi")]
 	self::wifi::ඞ::network_task(msg_signals).await;
+	#[cfg(feature = "net-ble")]
+	self::ble::ඞ::network_task(msg_signals).await;
 	#[cfg(feature = "net-stubbed")]
 	stubbed_network_task(msg_signals).await;
 }

--- a/firmware/src/peripherals/esp32.rs
+++ b/firmware/src/peripherals/esp32.rs
@@ -50,7 +50,7 @@ pub fn get_peripherals() -> Peripherals<I2cConcrete<'static>, DelayConcrete> {
 	esp32_hal::embassy::init(&clocks, timer0);
 
 	// Initialize esp-wifi stuff
-	#[cfg(feature = "net-wifi")]
+	#[cfg(feature = "esp-wifi")]
 	{
 		esp_wifi::init_heap();
 		let timerg = TimerGroup::new(p.TIMG1, &clocks);

--- a/firmware/src/peripherals/esp32c3.rs
+++ b/firmware/src/peripherals/esp32c3.rs
@@ -2,6 +2,7 @@ use super::Peripherals;
 use crate::aliases::ඞ::DelayConcrete;
 use crate::aliases::ඞ::I2cConcrete;
 
+use esp32c3_hal::Rng;
 use fugit::RateExtU32;
 use paste::paste;
 
@@ -50,13 +51,14 @@ pub fn get_peripherals() -> Peripherals<I2cConcrete<'static>, DelayConcrete> {
 	esp32c3_hal::embassy::init(&clocks, timer0);
 
 	// Initialize esp-wifi stuff
-	#[cfg(feature = "net-wifi")]
+	#[cfg(feature = "esp-wifi")]
 	{
 		use esp32c3_hal::systimer::SystemTimer;
 
 		esp_wifi::init_heap();
 		let systimer = SystemTimer::new(p.SYSTIMER);
-		esp_wifi::initialize(systimer.alarm0, p.RNG, &clocks)
+		let rng = Rng::new(p.RNG);
+		esp_wifi::initialize(systimer.alarm0, rng, &clocks)
 			.expect("failed to initialize esp-wifi");
 	}
 


### PR DESCRIPTION
This is just ground work for adding proper BLE support. Creates a BLE advertising service with name "SlimeVR-Rust"

The pure rust BLE stack situation looks quite dire. Rubble was an existing project, but has been archived about 8 months ago. Bleps is very basic and only provides a handful of operations. BLE is abstracted at protocol level through the HCI model, but even then writing our own stack is not trivial
