### PR TITLE
Imu traits take 2

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
  "futures-util",
  "load-dotenv",
  "mpu6050-dmp",
- "nalgebra 0.31.4",
+ "nalgebra",
  "nb 1.0.0",
  "nrf-softdevice",
  "nrf52832-pac",
@@ -963,7 +963,7 @@ name = "firmware_protocol"
 version = "0.0.0"
 dependencies = [
  "deku",
- "nalgebra 0.31.4",
+ "nalgebra",
 ]
 
 [[package]]
@@ -1232,21 +1232,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "simba 0.7.3",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6515c882ebfddccaa73ead7320ca28036c4bc84c9bcca3cc0cbba8efe89223a"
-dependencies = [
- "approx",
- "num-complex",
- "num-rational",
- "num-traits",
- "simba 0.8.0",
+ "simba",
  "typenum",
 ]
 
@@ -1710,18 +1696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simba"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50582927ed6f77e4ac020c057f37a268fc6aebc29225050365aacbb9deeeddc4"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
-]
-
-[[package]]
 name = "smoltcp"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,14 +1942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "vqf"
-version = "0.1.0"
-dependencies = [
- "nalgebra 0.32.1",
- "num-traits",
 ]
 
 [[package]]

--- a/firmware/src/imu/drivers/stubbed.rs
+++ b/firmware/src/imu/drivers/stubbed.rs
@@ -1,4 +1,4 @@
-use crate::imu::{FusedImu, Quat};
+use crate::imu::{FusedData, Imu, Quat};
 
 use defmt::debug;
 use embedded_hal::blocking::delay::DelayMs;
@@ -7,13 +7,16 @@ use firmware_protocol::ImuType;
 /// Fakes an IMU for easier testing.
 struct FakeImu;
 
-impl FusedImu for FakeImu {
+impl Imu for FakeImu {
 	type Error = ();
+	type Data = FusedData;
 
 	const IMU_TYPE: ImuType = ImuType::Unknown(0xFF);
 
-	fn quat(&mut self) -> nb::Result<Quat, Self::Error> {
-		Ok(Quat::identity())
+	async fn next_data(&mut self) -> Result<Self::Data, Self::Error> {
+		Ok(FusedData {
+			q: Quat::identity(),
+		})
 	}
 }
 
@@ -21,7 +24,7 @@ impl FusedImu for FakeImu {
 pub fn new_imu(
 	_i2c: impl crate::aliases::I2c,
 	_delay: &mut impl DelayMs<u32>,
-) -> impl crate::imu::FusedImu {
+) -> impl Imu<Data = FusedData> {
 	debug!("Created FakeImu");
 	FakeImu
 }

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -8,6 +8,8 @@
 #![feature(alloc_error_handler)]
 // We want to do some floating point math at compile time
 #![feature(const_fn_floating_point_arithmetic)]
+// We need async traits for efficient yet generic IMUs
+#![feature(async_fn_in_trait)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 load_dotenv::try_load_dotenv!();


### PR DESCRIPTION
I added an imu trait. Originally I was thinking there would be a fused and unfused imu, but it makes far more sense for there to just be one imu trait generic on its associated type, and that type can be fused or unfused. Also there was disagreement before on how to name stuff, like whether its `RawImu` or `Imu` or `FusedImu`. This makes that no longer necessary because all imus are the `Imu` trait.

I also added a `FusedImu` struct that we can use to combine an unfused imu with a `Fuser`. The idea is that the `Fuser` is purely a math thing. It could be *any* fusion algorithm.

One thing that remains to be solved is where filtering comes into the picture. If possible I think we should punt that to a later design iteration, when we have a need for it. Its possible that `FusedImu` is the one without filtering, and `FilteredFusedImu` has filtering also, which also implements `Imu<Data=FusedData>`. I'm not really sure which is why I think we should deal with it later in favor of unblocking present work.

I did not touch any of the business logic of the current imu implementations (such as the bmi160) as I felt that was out of scope.
The bmi160 should become an unfused type in a followup pr, and we should also refactor the nonblocking imu functions into async blocking ones, if we can figure out how to do that using proper async (might be hard, because most drivers use a non-async blocking api).