### PR TITLE
feat: rotate log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # IDE stuff
 /workspace.code-workspace
 /.vscode/
+
+# Logs
+**/*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +55,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "approx"
@@ -68,6 +83,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "async-recursion"
@@ -130,7 +151,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap 2.34.0",
- "env_logger 0.9.3",
+ "env_logger",
  "itertools 0.10.5",
  "lazy_static",
  "lazycell",
@@ -151,7 +172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "807778f48a2c408a1d637c41e6e122ddd370ad64996e4d02fe16222195e6c968"
 dependencies = [
  "autocxx-engine",
- "env_logger 0.9.3",
+ "env_logger",
  "syn",
 ]
 
@@ -323,6 +344,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
 
 [[package]]
 name = "clang-sys"
@@ -536,6 +572,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx-build"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
 name = "cxx-gen"
 version = "0.7.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +707,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +729,12 @@ dependencies = [
  "rustc_version",
  "syn",
 ]
+
+[[package]]
+name = "destructure_traitobject"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
 name = "digest"
@@ -695,25 +763,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -928,7 +983,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1050,15 +1105,6 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -1098,6 +1144,30 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1280,6 +1350,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "serde",
+]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
+name = "log4rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "derivative",
+ "fnv",
+ "humantime",
+ "libc",
+ "log",
+ "log-mdc",
+ "parking_lot",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "thread-id",
+ "typemap-ors",
+ "winapi",
 ]
 
 [[package]]
@@ -1372,7 +1475,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
 ]
 
@@ -1669,6 +1772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,16 +1936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger 0.7.1",
- "log",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,12 +1973,6 @@ checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2074,6 +2170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,6 +2242,16 @@ name = "serde-rename-rule"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2930103714ccef4f1fe5b6a5f2b6fdcfe462a6c802464714bd41e5b5097c33"
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
 
 [[package]]
 name = "serde_derive"
@@ -2297,11 +2409,11 @@ dependencies = [
  "git-version",
  "lazy_static",
  "log",
+ "log4rs",
  "nalgebra 0.30.1",
  "num-derive",
  "num-traits",
  "ovr_overlay",
- "pretty_env_logger",
  "solarxr",
  "stackvec",
  "tokio",
@@ -2453,12 +2565,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -2641,6 +2775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "typemap-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
+dependencies = [
+ "unsafe-any-ors",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,6 +2821,15 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unsafe-any-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
+dependencies = [
+ "destructure_traitobject",
+]
 
 [[package]]
 name = "url"
@@ -2738,6 +2890,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/overlay/Cargo.toml
+++ b/overlay/Cargo.toml
@@ -17,12 +17,12 @@ nalgebra = "0.30"
 num-derive = "0.3"
 num-traits = "0.2"
 ovr_overlay = { version = "=0.0.0", features = ["nalgebra"] }
-pretty_env_logger = "0.4"
 stackvec = "0.2"
 tokio = { version = "1", features = ["full"] }
 solarxr = { path = "../networking/solarxr" }
 tokio-graceful-shutdown = "0.11"
 git-version = "0.3"
+log4rs = "1.2.0"
 
 eyre.workspace = true
 log.workspace = true

--- a/overlay/logfile.log
+++ b/overlay/logfile.log
@@ -1,0 +1,5 @@
+INFO - 2023-02-18 21:22:06 - Overlay version: 2f0f931-modified
+INFO - 2023-02-18 21:22:06 - Initializing OpenVR context
+INFO - 2023-02-18 21:22:06 - Overlay Loop
+ERROR - 2023-02-18 21:22:10 - Error while connecting: IO error: 無法連線，因為目標電腦拒絕連線。 (os error 10061)
+ERROR - 2023-02-18 21:22:14 - Error while connecting: IO error: 無法連線，因為目標電腦拒絕連線。 (os error 10061)

--- a/overlay/logfile.log
+++ b/overlay/logfile.log
@@ -1,5 +1,0 @@
-INFO - 2023-02-18 21:22:06 - Overlay version: 2f0f931-modified
-INFO - 2023-02-18 21:22:06 - Initializing OpenVR context
-INFO - 2023-02-18 21:22:06 - Overlay Loop
-ERROR - 2023-02-18 21:22:10 - Error while connecting: IO error: 無法連線，因為目標電腦拒絕連線。 (os error 10061)
-ERROR - 2023-02-18 21:22:14 - Error while connecting: IO error: 無法連線，因為目標電腦拒絕連線。 (os error 10061)

--- a/overlay/src/main.rs
+++ b/overlay/src/main.rs
@@ -58,7 +58,7 @@ fn init_log(show_log: bool) -> Result<()> {
 		std::fs::remove_file(logfile_name)?;
 	}
 
-	let log_pattern = PatternEncoder::new("{h({l})} - {d(%Y-%m-%d %H:%M:%S)} - {m}{n}");
+	let log_pattern = "{h({l})} - {d(%Y-%m-%d %H:%M:%S)} - {m}{n}";
 
 	let window_size = 2;
 	let fixed_window_roller = FixedWindowRoller::builder()
@@ -71,7 +71,7 @@ fn init_log(show_log: bool) -> Result<()> {
 		CompoundPolicy::new(Box::new(size_trigger), Box::new(fixed_window_roller));
 
 	let rolling_file_appender = RollingFileAppender::builder()
-		.encoder(Box::new(log_pattern.clone()))
+		.encoder(Box::new(PatternEncoder::new(log_pattern)))
 		.build(logfile_name, Box::new(compound_policy))?;
 
 	let mut config_builder = Config::builder();
@@ -84,14 +84,14 @@ fn init_log(show_log: bool) -> Result<()> {
 
 	if show_log {
 		let stdout = ConsoleAppender::builder()
-			.encoder(Box::new(log_pattern.clone()))
+			.encoder(Box::new(PatternEncoder::new(log_pattern)))
 			.build();
 		root_builder = root_builder.appender("stdout");
 		config_builder = config_builder
 			.appender(Appender::builder().build("stdout", Box::new(stdout)));
 	}
 
-	let config = config_builder.build(root_builder.build(LevelFilter::Warn))?;
+	let config = config_builder.build(root_builder.build(LevelFilter::Info))?;
 
 	let _log = log4rs::init_config(config)?;
 

--- a/overlay/src/main.rs
+++ b/overlay/src/main.rs
@@ -9,6 +9,11 @@ use crate::model::{BoneKind, Isometry};
 use clap::Parser;
 use eyre::{Result, WrapErr};
 use git_version::git_version;
+use log4rs::append::rolling_file::policy::compound::roll::fixed_window::FixedWindowRoller;
+use log4rs::append::rolling_file::policy::compound::trigger::size::SizeTrigger;
+use log4rs::append::rolling_file::policy::compound::CompoundPolicy;
+use log4rs::append::rolling_file::RollingFileAppender;
+use log4rs::encode::pattern::PatternEncoder;
 use nalgebra::{Translation3, UnitQuaternion};
 use ovr_overlay as ovr;
 use solarxr::settings::DisplaySettings;
@@ -18,12 +23,19 @@ use std::time::Duration;
 use tokio::sync::watch;
 use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
+use log::LevelFilter;
+use log4rs::append::console::ConsoleAppender;
+use log4rs::config::{Appender, Config, Root};
+
 const CONNECT_STR: &str = "ws://localhost:21110";
 const GIT_VERSION: &str = git_version!();
 
 #[derive(Parser, Debug)]
 #[command(version = GIT_VERSION)]
-struct Args {}
+struct Args {
+	#[arg(short, long, default_value_t = false)]
+	show_log: bool,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ShutdownReason {
@@ -40,15 +52,63 @@ macro_rules! unwrap_or_continue {
 	}};
 }
 
+fn init_log(show_log: bool) -> Result<()> {
+	let logfile_name = "logfile.log";
+	if std::path::Path::new(logfile_name).exists() {
+		std::fs::remove_file(logfile_name)?;
+	}
+
+	let log_pattern = PatternEncoder::new("{h({l})} - {d(%Y-%m-%d %H:%M:%S)} - {m}{n}");
+
+	let window_size = 2;
+	let fixed_window_roller = FixedWindowRoller::builder()
+		.build("log_last_{}.log", window_size)
+		.unwrap();
+	let size_limit = 25 * 1024; // 25MB
+	let size_trigger = SizeTrigger::new(size_limit);
+
+	let compound_policy =
+		CompoundPolicy::new(Box::new(size_trigger), Box::new(fixed_window_roller));
+
+	let rolling_file_appender = RollingFileAppender::builder()
+		.encoder(Box::new(log_pattern.clone()))
+		.build(logfile_name, Box::new(compound_policy))?;
+
+	let mut config_builder = Config::builder();
+	let mut root_builder = Root::builder();
+
+	root_builder = root_builder.appender("logfile");
+	config_builder = config_builder.appender(
+		Appender::builder().build("logfile", Box::new(rolling_file_appender)),
+	);
+
+	if show_log {
+		let stdout = ConsoleAppender::builder()
+			.encoder(Box::new(log_pattern.clone()))
+			.build();
+		root_builder = root_builder.appender("stdout");
+		config_builder = config_builder
+			.appender(Appender::builder().build("stdout", Box::new(stdout)));
+	}
+
+	let config = config_builder.build(root_builder.build(LevelFilter::Warn))?;
+
+	let _log = log4rs::init_config(config)?;
+
+	Ok(())
+}
+
 #[tokio::main]
 pub async fn main() -> Result<()> {
 	if std::env::var("RUST_LOG").is_err() {
 		std::env::set_var("RUST_LOG", "info");
 	}
-	pretty_env_logger::init();
+
+	let args = Args::parse();
+
+	init_log(args.show_log)?;
 	color_eyre::install()?;
 
-	let _args = Args::parse();
 	log::info!("Overlay version: {GIT_VERSION}");
 
 	Toplevel::new()


### PR DESCRIPTION
Related to https://github.com/SlimeVR/SlimeVR-Rust/issues/81

- [x] size limiter
- [x] Rolling log
- [x] add CLI Arg
- [x] color output

The rolling mechanism here is a bit different,
The primary log file path is "logfile" and then the rolling file path is the 'archive' path. It will fill up the primary and then send it to the archive when that is full

Not too sure about the error handling here (beginner in rust ), let me know if you have any better way to do so.
