### PR TITLE
Output logs to stdout by default

### DIFF
--- a/overlay/src/main.rs
+++ b/overlay/src/main.rs
@@ -33,7 +33,7 @@ const GIT_VERSION: &str = git_version!();
 #[derive(Parser, Debug)]
 #[command(version = GIT_VERSION)]
 struct Args {
-	#[arg(short, long, default_value_t = false)]
+	#[arg(short, long, default_value_t = true)]
 	show_log: bool,
 }
 


### PR DESCRIPTION
#187 has the logs not printing to stdout by default, but I think this is undesirable, at least until we stop showing the cli.