### PR TITLE
[Firmware] Improve how net-* flags are handled

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 * @thebutlah
-/autoupdater @TheDevMinerTV
 
 # People need to be able to update these
 /Cargo.lock

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -33,40 +33,38 @@ default = [
 
 # Supported microcontrollers
 mcu-esp32 = [
+  "_mcu-f-esp32",
   "dep:esp32-hal",
   "defmt_esp_println/esp32",
   "esp-backtrace/esp32",
   "xtensa-lx/esp32",
-  "dep:esp-alloc",
-  "dep:embedded-svc",
-  "esp-wifi?/esp32",
+  "esp-wifi/esp32",
 ]
 mcu-esp32c3 = [
+  "_mcu-f-esp32",
   "dep:esp32c3-hal",
   "defmt_esp_println/esp32c3",
   "esp-backtrace/esp32c3",
   "dep:riscv",
-  "dep:esp-alloc",
-  "dep:embedded-svc",
-  "esp-wifi?/esp32c3",
+  "esp-wifi/esp32c3",
 ]
 mcu-nrf52840 = [
+  "_mcu-f-nrf52",
   "embassy-nrf/nrf52840",
   "dep:embassy-usb",
-  "nrf-softdevice?/nrf52840",
-  "_mcu-f-nrf52",
+  "nrf-softdevice/nrf52840",
   "dep:nrf52840-pac",
 ]
 mcu-nrf52832 = [
-  "embassy-nrf/nrf52832",
-  "nrf-softdevice?/nrf52832",
   "_mcu-f-nrf52",
+  "embassy-nrf/nrf52832",
+  "nrf-softdevice/nrf52832",
   "dep:nrf52832-pac",
 ]
 
 # Wi-fi dependencies
-net-wifi = ["esp-wifi/wifi", "dep:embassy-net", "dep:smoltcp"]                 # use wifi
-net-ble = ["esp-wifi/ble", "dep:bleps", "dep:bleps-macros"]
+net-wifi = ["esp-wifi?/wifi"]                 # use wifi
+net-ble = ["esp-wifi?/ble"]
 net-stubbed = []                                            # Stubs out network
 
 # Supported IMUs
@@ -101,7 +99,16 @@ _mcu-f-nrf52 = [
   "dep:alloc-cortex-m",
   "embassy-nrf/time-driver-rtc1",
   "embassy-executor/integrated-timers",
-  "defmt-bbq",
+  "dep:defmt-bbq",
+]
+
+_mcu-f-esp32 = [
+  "dep:esp-alloc",
+  "dep:embedded-svc",
+  "dep:embassy-net",
+  "dep:smoltcp",
+  "dep:bleps",
+  "dep:bleps-macros",
 ]
 
 [dependencies]

--- a/firmware/src/networking/ble/mod.rs
+++ b/firmware/src/networking/ble/mod.rs
@@ -1,3 +1,7 @@
-#[cfg(feature = "net-ble")]
+#[cfg(mcu_f_esp32)]
 #[path = "esp.rs"]
+pub mod ඞ;
+
+#[cfg(mcu_f_nrf52)]
+#[path = "nrf52.rs"]
 pub mod ඞ;

--- a/firmware/src/networking/ble/nrf52.rs
+++ b/firmware/src/networking/ble/nrf52.rs
@@ -1,0 +1,9 @@
+use embassy_time::{Duration, Timer};
+
+use crate::{aliases::ඞ::NetConcrete, networking::protocol::Packets};
+
+pub async fn network_task(_packets: &Packets, _net: NetConcrete) -> ! {
+	loop {
+		Timer::after(Duration::from_millis(10_000)).await
+	}
+}

--- a/firmware/src/networking/mod.rs
+++ b/firmware/src/networking/mod.rs
@@ -1,4 +1,5 @@
 pub mod protocol;
+
 #[cfg(feature = "net-wifi")]
 pub mod wifi;
 

--- a/firmware/src/networking/wifi/mod.rs
+++ b/firmware/src/networking/wifi/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "net-wifi")]
+#[cfg(mcu_f_esp32)]
 #[path = "esp.rs"]
 pub mod ඞ;
 


### PR DESCRIPTION
Makes the code give more helpful errors when using net-wifi on nrf, and restructures things a bit to improve developer experience