### PR TITLE
Reduce update when angle not changing and sleep esp modem

### DIFF
--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 [features]
 default = [
   "mcu-esp32c3",
-  "imu-stubbed",
+  "imu-mpu6050",
   "log-rtt",
   "net-wifi",
   "fusion-stubbed",
@@ -213,6 +213,7 @@ nalgebra = { version = "0.31", default-features = false, features = [
   "macros",
   "libm",
 ] }
+approx = "0.5.1"
 fugit = "0.3"
 firmware_protocol = { path = "../networking/firmware_protocol", features = [
   "nalgebra031",

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -167,6 +167,7 @@ esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", rev = "76ba312", fe
   "embedded-svc",
   "wifi",
   "embassy-net",
+  "ps-min-modem",
 ], optional = true }
 smoltcp = { version = "0.9", default-features = false, features = [
 ], optional = true }

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 [features]
 default = [
   "mcu-esp32c3",
-  "imu-mpu6050",
+  "imu-stubbed",
   "log-rtt",
   "net-wifi",
   "fusion-stubbed",

--- a/firmware/src/imu/mod.rs
+++ b/firmware/src/imu/mod.rs
@@ -1,10 +1,10 @@
 mod drivers;
 mod fusion;
 
+use approx::AbsDiffEq;
 use defmt::{debug, info, trace, warn};
 use embassy_executor::task;
 use firmware_protocol::ImuType;
-use approx::AbsDiffEq;
 
 use crate::{
 	aliases::ඞ::{DelayConcrete, I2cConcrete},


### PR DESCRIPTION
Compare the angle with previous transmitted one after each imu data, and only transmit when the new angle is with significant difference.

Adopted method and parameter from the Arduino repo. Will leave radio inactive time at idle, thus reduce idle power consumption after modem sleep implemented in the protocol stack.